### PR TITLE
[9522] Add workflow to automate SDK version bumps 

### DIFF
--- a/.github/workflows/bump-native-sdks.yml
+++ b/.github/workflows/bump-native-sdks.yml
@@ -1,0 +1,97 @@
+# Bump Native SDK version numbers whenever a repository dispatch of a new
+# release is received
+name: Bump Native SDKs
+on:
+  repository_dispatch:
+    types: ['ios-sdk-release', 'android-sdk-release']
+jobs:
+  update_android_sdk_version:
+    runs-on: ubuntu-latest
+    if: github.event.client_payload.platform == "android"
+    steps:
+      - name: Event Information
+        run: echo ${{ github.event.client_payload.release }}
+
+      # checkout the repo
+      - uses: actions/checkout@v2
+
+      # copy the template file to its final destination
+      - name: Copy android/build.gradle template file
+        uses: canastro/copy-action@master
+        with:
+          source: "android/build.gradle.template"
+          target: "android/build.gradle"
+
+      # render the template using the input sdk version
+      - name: Render radar-sdk-android release version onto build.gradle
+        uses: jayamanikharyono/jinja-action@v0.1
+        with:
+          data: version=${{ github.event.client_payload.release }}
+          path: "android/build.gradle"
+
+      # copy the pubspec.yaml template to its final destination
+      - name: Copy the podspec template
+        uses: canastro/copy-action@master
+        with:
+          source: "pubspec.yaml.template"
+          target: "pubspec.yaml"
+
+      # render the pubspec.yaml template with the sdk version
+      - name: Render radar-sdk-ios release version onto podspec template
+        uses: jayamanikharyono/jinja-action@v0.1
+        with:
+          data: version=${{ github.event.client_payload.release }}
+          path: "pubspec.yaml"
+
+      # open a pull request with the new sdk version
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: Automated radar-sdk-android version bump to ${{ github.event.client_payload.release }}
+          reviewers: radarlabs/eng
+          token: ${{ secrets.GITHUB_TOKEN }}
+  update_ios_sdk_version:
+    runs-on: ubuntu-latest
+    if: github.event.client_payload.platform == 'ios'
+    steps:
+      - name: Event Information
+        run: echo ${{ github.event.client_payload.release }}
+
+      # checkout the repo
+      - uses: actions/checkout@v2
+
+      # copy the podspec template to its final destination
+      - name: Copy the podspec template
+        uses: canastro/copy-action@master
+        with:
+          source: "flutter_radar.podspec.template"
+          target: "flutter_radar.podspec"
+
+      # render the podspec template with the sdk version
+      - name: Render radar-sdk-ios release version onto podspec template
+        uses: jayamanikharyono/jinja-action@v0.1
+        with:
+          data: version=${{ github.event.client_payload.release }}
+          path: "flutter_radar.podspec"
+
+      # copy the pubspec.yaml template to its final destination
+      - name: Copy the podspec template
+        uses: canastro/copy-action@master
+        with:
+          source: "pubspec.yaml.template"
+          target: "pubspec.yaml"
+
+      # render the pubspec.yaml template with the sdk version
+      - name: Render radar-sdk-ios release version onto podspec template
+        uses: jayamanikharyono/jinja-action@v0.1
+        with:
+          data: version=${{ github.event.client_payload.release }}
+          path: "pubspec.yaml"
+
+      # open a pull request with the new sdk version
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: Automated radar-sdk-ios version bump to ${{ github.event.client_payload.release }}
+          reviewers: radarlabs/eng
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/android/build..gradle.template
+++ b/android/build..gradle.template
@@ -1,0 +1,39 @@
+group 'io.radar.flutter'
+version '1.0'
+
+buildscript {
+    repositories {
+        google()
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.5.0'
+    }
+}
+
+rootProject.allprojects {
+    repositories {
+        google()
+        jcenter()
+    }
+}
+
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 29
+
+    defaultConfig {
+        minSdkVersion 16
+    }
+    lintOptions {
+        disable 'InvalidPackage'
+    }
+}
+
+dependencies {
+    implementation 'io.radar:sdk:{{ version }}'
+    implementation 'com.google.android.gms:play-services-location:17.0.0'
+    implementation 'com.google.code.gson:gson:2.8.6'
+}

--- a/ios/flutter_radar.podspec.template
+++ b/ios/flutter_radar.podspec.template
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name             = 'flutter_radar'
+  s.version          = '{{ version }}'
+  s.summary          = 'Flutter package for Radar, the leading geofencing and location tracking platform'
+  s.description      = 'Flutter package for Radar, the leading geofencing and location tracking platform'
+  s.homepage         = 'http://example.com'
+  s.license          = { :file => '../LICENSE' }
+  s.author           = { 'Radar Labs, Inc.' => 'support@radar.io' }
+  s.source           = { :path => '.' }
+  s.source_files = 'Classes/**/*'
+  s.public_header_files = 'Classes/**/*.h'
+  s.dependency 'Flutter'
+  s.dependency 'RadarSDK', '{{ version }}'
+  s.platform = :ios, '10.0'
+  s.static_framework = true
+
+  # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+end

--- a/pubspec.yaml.template
+++ b/pubspec.yaml.template
@@ -1,0 +1,25 @@
+name: flutter_radar
+description: Flutter package for Radar, the leading geofencing and location tracking platform
+version: {{ version }}
+homepage: https://github.com/radarlabs/flutter-radar
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+  flutter: ">=1.20.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  plugin:
+    platforms:
+      android:
+        package: io.radar.flutter
+        pluginClass: RadarFlutterPlugin
+      ios:
+        pluginClass: RadarFlutterPlugin


### PR DESCRIPTION
## Summary
Added a workflow that bumps the version whenever the repo receives a `repository_dispatch` github event from our native SDKs: [Android SDK](https://github.com/radarlabs/radar-sdk-android) or [iOS SDK](https://github.com/radarlabs/radar-sdk-ios).

It'll update:
- `android/build.gradle` for Android releases
- `ios/flutter_radar.podspec` for iOS releases
- `pubspec.yaml` for all releases