### PR TITLE
[Automation | SC-9526] Fix Github Actions

### DIFF
--- a/.github/workflows/bump-native-sdks.yml
+++ b/.github/workflows/bump-native-sdks.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update_android_sdk_version:
     runs-on: ubuntu-latest
-    if: github.event.client_payload.platform == "android"
+    if: github.event.client_payload.platform == 'android'
     steps:
       - name: Event Information
         run: echo ${{ github.event.client_payload.release }}
@@ -19,43 +19,43 @@ jobs:
       - name: Copy android/build.gradle template file
         uses: canastro/copy-action@master
         with:
-          source: "android/build.gradle.template"
-          target: "android/build.gradle"
+          source: 'android/build.gradle.template'
+          target: 'android/build.gradle'
 
       # render the template using the input sdk version
       - name: Render radar-sdk-android release version onto build.gradle
         uses: jayamanikharyono/jinja-action@v0.1
         with:
           data: version=${{ github.event.client_payload.release }}
-          path: "android/build.gradle"
+          path: 'android/build.gradle'
 
       # copy the template file to its final destination
       - name: Copy example/android/app/build.gradle template file
         uses: canastro/copy-action@master
         with:
-          source: "example/android/app/build.gradle.template"
-          target: "example/android/app/build.gradle"
+          source: 'example/android/app/build.gradle.template'
+          target: 'example/android/app/build.gradle'
 
       # render the template using the input sdk version
       - name: Render radar-sdk-android release version onto example app's build.gradle
         uses: jayamanikharyono/jinja-action@v0.1
         with:
           data: version=${{ github.event.client_payload.release }}
-          path: "example/android/app/build.gradle"
+          path: 'example/android/app/build.gradle'
 
       # copy the pubspec.yaml template to its final destination
       - name: Copy the pubspec.yml template
         uses: canastro/copy-action@master
         with:
-          source: "pubspec.yaml.template"
-          target: "pubspec.yaml"
+          source: 'pubspec.yaml.template'
+          target: 'pubspec.yaml'
 
       # render the pubspec.yaml template with the sdk version
       - name: Render radar-sdk-android release version onto pubspec.yaml
         uses: jayamanikharyono/jinja-action@v0.1
         with:
           data: version=${{ github.event.client_payload.release }}
-          path: "pubspec.yaml"
+          path: 'pubspec.yaml'
 
       # open a pull request with the new sdk version
       - name: Create Pull Request
@@ -78,29 +78,29 @@ jobs:
       - name: Copy the podspec template
         uses: canastro/copy-action@master
         with:
-          source: "flutter_radar.podspec.template"
-          target: "flutter_radar.podspec"
+          source: 'flutter_radar.podspec.template'
+          target: 'flutter_radar.podspec'
 
       # render the podspec template with the sdk version
       - name: Render radar-sdk-ios release version onto podspec template
         uses: jayamanikharyono/jinja-action@v0.1
         with:
           data: version=${{ github.event.client_payload.release }}
-          path: "flutter_radar.podspec"
+          path: 'flutter_radar.podspec'
 
       # copy the pubspec.yaml template to its final destination
       - name: Copy the podspec template
         uses: canastro/copy-action@master
         with:
-          source: "pubspec.yaml.template"
-          target: "pubspec.yaml"
+          source: 'pubspec.yaml.template'
+          target: 'pubspec.yaml'
 
       # render the pubspec.yaml template with the sdk version
       - name: Render radar-sdk-ios release version onto podspec template
         uses: jayamanikharyono/jinja-action@v0.1
         with:
           data: version=${{ github.event.client_payload.release }}
-          path: "pubspec.yaml"
+          path: 'pubspec.yaml'
 
       # open a pull request with the new sdk version
       - name: Create Pull Request


### PR DESCRIPTION
## Summary
[Expressions in Github actions](https://docs.github.com/en/actions/learn-github-actions/expressions#literals
) need to use single quotes. See issue [here](https://github.com/actions/runner/issues/866).

Swapped out all double quotes in the `bump-native-sdks.yml` file for consistency 