### PR TITLE
sc-11025: Replace radar.io addresses with radar.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 [![npm](https://img.shields.io/pub/v/flutter_radar)](https://pub.dev/packages/flutter_radar)
 
-[Radar](https://radar.io) is the leading geofencing and location tracking platform.
+[Radar](https://radar.com) is the leading geofencing and location tracking platform.
 
 The Radar SDK abstracts away cross-platform differences between location services, allowing you to add geofencing, location tracking, trip tracking, geocoding, and search to your apps with just a few lines of code.
 
 ## Documentation
 
-See the Radar overview documentation [here](https://radar.io/documentation).
+See the Radar overview documentation [here](https://radar.com/documentation).
 
-Then, see the Flutter package documentation [here](https://radar.io/documentation/sdk/flutter).
+Then, see the Flutter package documentation [here](https://radar.com/documentation/sdk/flutter).
 
 ## Examples
 
@@ -18,4 +18,4 @@ See an example app in `example/`.
 
 ## Support
 
-Have questions? We're here to help! Email us at [support@radar.io](mailto:support@radar.io).
+Have questions? We're here to help! Email us at [support@radar.com](mailto:support@radar.com).

--- a/ios/flutter_radar.podspec
+++ b/ios/flutter_radar.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.description      = 'Flutter package for Radar, the leading geofencing and location tracking platform'
   s.homepage         = 'http://example.com'
   s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Radar Labs, Inc.' => 'support@radar.io' }
+  s.author           = { 'Radar Labs, Inc.' => 'support@radar.com' }
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'


### PR DESCRIPTION
[sc-11025: [Flutter SDK] radar.io => radar.com](https://app.shortcut.com/radarlabs/story/11025/flutter-sdk-radar-io-radar-com)

Updates all Radar email addresses and URLs to use radar.com.