### PR TITLE
Gabrielalao/fence 1339 upgrade flutter sdk to latest ios and android radar sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.1.8
+# 3.2.0
 
 - Bump iOS version from 3.5.9 to 3.8.9
 - Bump android version from 3.5.9 to 3.8.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 3.1.8
+
+- Bump iOS version from 3.5.9 to 3.8.9
+- Bump android version from 3.5.9 to 3.8.12
+- remove `setAdIdEnabled`
+- rename `sendEvent` to `logConversion` and add `revenue` param
+- add `trackVerified`
+- add `trackVerifiedToken`
+- add `isUsingRemoteTrackingOptions`
+- update `autocompleteQuery` with param add `expandUnits`
+- add `validateAddress`
+- add `App Attest` to ios example
+- add `Play Integrity API` to android example
+- update example project
+
 # 3.1.7
 
 - Update ios event channel

--- a/MIGRATION.MD
+++ b/MIGRATION.MD
@@ -16,7 +16,7 @@ var resp = await Radar.logConversion(
 ```
 
 ```dart
-// 3.1.x - logging conversions
+// 3.1.x - sending events
 var resp = await Radar.sendEvent(
     customType: "in_app_purchase",
     location: {

--- a/MIGRATION.MD
+++ b/MIGRATION.MD
@@ -1,11 +1,8 @@
 # Migration guides
 
 ## 3.1.x to 3.2.0
-- The `Radar.setAdIdEnabled()` method has been removed.
+- `Radar.setAdIdEnabled()` has been removed.
 - Custom events have been renamed to conversions.
     - `Radar.sendEvent(customType, location, metadata)` is now `Radar.logConversion(name, revenue, metadata)`.
     - The method response does not include `location` and `user` props anymore.
-- `Radar.autocomplete()` method has another optional param `expandUnits`
-- Fruad detection has been introduced
-    - `Radar.trackVerified()` has been added, but need to follow this instruction for both android and ios setup. See the [Fraud documentation](https://radar.com/documentation/fraud)
-- The SDK depends on Google Play Services Location version 21.0.1. See the [Android setup documentation](https://radar.com/documentation/sdk/android)
+

--- a/MIGRATION.MD
+++ b/MIGRATION.MD
@@ -6,3 +6,22 @@
     - `Radar.sendEvent(customType, location, metadata)` is now `Radar.logConversion(name, revenue, metadata)`.
     - The method response does not include `location` and `user` props anymore.
 
+
+```dart
+// 3.2.0 - logging conversions
+var resp = await Radar.logConversion(
+    name: "in_app_purchase",
+    revenue: 0.2,
+    metadata: {"price": "150USD"});
+```
+
+```dart
+// 3.1.x - logging conversions
+var resp = await Radar.sendEvent(
+    customType: "in_app_purchase",
+    location: {
+        "latitude": 35.0,
+        "longitude": -75.0
+    },
+    metadata: {"price": "150USD"});
+```

--- a/MIGRATION.MD
+++ b/MIGRATION.MD
@@ -1,0 +1,11 @@
+# Migration guides
+
+## 3.1.x to 3.2.0
+- The `Radar.setAdIdEnabled()` method has been removed.
+- Custom events have been renamed to conversions.
+    - `Radar.sendEvent(customType, location, metadata)` is now `Radar.logConversion(name, revenue, metadata)`.
+    - The method response does not include `location` and `user` props anymore.
+- `Radar.autocomplete()` method has another optional param `expandUnits`
+- Fruad detection has been introduced
+    - `Radar.trackVerified()` has been added, but need to follow this instruction for both android and ios setup. See the [Fraud documentation](https://radar.com/documentation/fraud)
+- The SDK depends on Google Play Services Location version 21.0.1. See the [Android setup documentation](https://radar.com/documentation/sdk/android)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-    implementation 'io.radar:sdk:3.5.9'
-    implementation 'com.google.android.gms:play-services-location:17.0.0'
+    implementation 'io.radar:sdk:3.8.12'
+    implementation 'com.google.android.gms:play-services-location:21.0.1'
     implementation 'com.google.code.gson:gson:2.8.6'
 }

--- a/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
+++ b/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
@@ -229,6 +229,9 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
                 case "isTracking":
                     isTracking(result);
                     break;
+                case "isUsingRemoteTrackingOptions":
+                    isUsingRemoteTrackingOptions(result);
+                    break;
                 case "getTrackingOptions":
                     getTrackingOptions(result);
                     break;
@@ -1193,6 +1196,11 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
         };
 
         Radar.trackVerifiedToken(callback);
+    }
+
+    private void isUsingRemoteTrackingOptions(Result result) {
+        Boolean isRemoteTracking = Radar.isUsingRemoteTrackingOptions();
+        result.success(isRemoteTracking);
     }
 
     private Location locationForMap(HashMap locationMap) {

--- a/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
+++ b/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
@@ -198,9 +198,6 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
                 case "setAnonymousTrackingEnabled":
                     setAnonymousTrackingEnabled(call, result);
                     break;
-                case "setAdIdEnabled":
-                    // do nothing
-                    break;
                 case "getLocation":
                     getLocation(call, result);
                     break;

--- a/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
+++ b/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
@@ -286,6 +286,9 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
                 case "trackVerified":
                     trackVerified(call, result);
                     break;
+                case "trackVerifiedToken":
+                    trackVerifiedToken(call, result);
+                    break;
                 case "attachListeners":
                     attachListeners(call, result);
                     break;
@@ -1165,6 +1168,31 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
         };
 
         Radar.trackVerified(callback);
+    }
+
+    public void trackVerifiedToken(MethodCall call, final Result result) {
+        Radar.RadarTrackTokenCallback callback = new Radar.RadarTrackTokenCallback() {
+            @Override
+            public void onComplete(final Radar.RadarStatus status, final String token) {
+                runOnMainThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            JSONObject obj = new JSONObject();
+                            obj.put("status", status.toString());
+                            obj.put("token", token);
+
+                            HashMap<String, Object> map = new Gson().fromJson(obj.toString(), HashMap.class);
+                            result.success(map);
+                        } catch (Exception e) {
+                            result.error(e.toString(), e.getMessage(), e.getMessage());
+                        }
+                    }
+                });
+            }
+        };
+
+        Radar.trackVerifiedToken(callback);
     }
 
     private Location locationForMap(HashMap locationMap) {

--- a/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
+++ b/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
@@ -292,6 +292,9 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
                 case "trackVerifiedToken":
                     trackVerifiedToken(call, result);
                     break;
+                case "validateAddress":
+                    validateAddress(call, result);
+                    break;
                 case "attachListeners":
                     attachListeners(call, result);
                     break;
@@ -1201,6 +1204,39 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
     private void isUsingRemoteTrackingOptions(Result result) {
         Boolean isRemoteTracking = Radar.isUsingRemoteTrackingOptions();
         result.success(isRemoteTracking);
+    }
+
+    public void validateAddress(MethodCall call, final Result result) throws JSONException {
+        Radar.RadarValidateAddressCallback callback = new Radar.RadarValidateAddressCallback() {
+            @Override
+            public void onComplete(final Radar.RadarStatus status, final RadarAddress address, final Radar.RadarAddressVerificationStatus verificationStatus) {
+                runOnMainThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            JSONObject obj = new JSONObject();
+                            obj.put("status", status.toString());
+                            if (address != null) {
+                                //obj.put("address", address.toJson());
+                            }
+                            if (verificationStatus != null) {
+                                obj.put("verificationStatus", verificationStatus.toString());
+                            }
+
+                            HashMap<String, Object> map = new Gson().fromJson(obj.toString(), HashMap.class);
+                            result.success(map);
+                        } catch (Exception e) {
+                            result.error(e.toString(), e.getMessage(), e.getMessage());
+                        }
+                    }
+                });
+            }
+        };
+
+        HashMap addressMap= call.argument("address");
+        JSONObject addressJSON = jsonForMap(addressMap);
+        RadarAddress address = RadarAddress.fromJson(addressJSON);
+        Radar.validateAddress(address, callback);
     }
 
     private Location locationForMap(HashMap locationMap) {

--- a/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
+++ b/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
@@ -67,16 +67,6 @@ import io.flutter.view.FlutterCallbackInformation;
 public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, ActivityAware, RequestPermissionsResultListener {
 
     private static FlutterEngine sBackgroundFlutterEngine;
-    private static EventChannel sEventsChannel;
-    private static EventChannel.EventSink sEventsSink;
-    private static EventChannel sLocationChannel;
-    private static EventChannel.EventSink sLocationSink;
-    private static EventChannel sClientLocationChannel;
-    private static EventChannel.EventSink sClientLocationSink;
-    private static EventChannel sErrorChannel;
-    private static EventChannel.EventSink sErrorSink;
-    private static EventChannel sLogChannel;
-    private static EventChannel.EventSink sLogSink;
 
     private Activity mActivity;
     private Context mContext;

--- a/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
+++ b/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
@@ -1204,7 +1204,7 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
                             JSONObject obj = new JSONObject();
                             obj.put("status", status.toString());
                             if (address != null) {
-                                //obj.put("address", address.toJson());
+                                obj.put("address", address.toJson());
                             }
                             if (verificationStatus != null) {
                                 obj.put("verificationStatus", verificationStatus.toString());

--- a/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
+++ b/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
@@ -274,8 +274,8 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
                 case "getDistance":
                     getDistance(call, result);
                     break;
-                case "sendEvent":
-                    sendEvent(call, result);
+                case "logConversion":
+                    logConversion(call, result);
                     break;
                 case "getMatrix":
                     getMatrix(call, result);
@@ -1043,24 +1043,18 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
         }
     }
 
-    public void sendEvent(MethodCall call, final Result result) throws JSONException  {
-        Radar.RadarSendEventCallback callback = new Radar.RadarSendEventCallback() {
+    public void logConversion(MethodCall call, final Result result) throws JSONException  {
+        Radar.RadarLogConversionCallback callback = new Radar.RadarLogConversionCallback() {
             @Override
-            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable Location location, @Nullable RadarEvent[] events, @Nullable RadarUser user) {
+            public void onComplete(@NonNull Radar.RadarStatus status, @Nullable RadarEvent event) {
                 runOnMainThread(new Runnable() {
                     @Override
                     public void run() {
                         try {
                             JSONObject obj = new JSONObject();
                             obj.put("status", status.toString());
-                            if (location != null) {
-                                obj.put("location", Radar.jsonForLocation(location));
-                            }
-                            if (events != null) {
-                                obj.put("events", RadarEvent.toJson(events));
-                            }
-                            if (user != null) {
-                                obj.put("user", user.toJson());
+                            if (event != null) {
+                                obj.put("event", event.toJson());
                             }
       
                             HashMap<String, Object> map = new Gson().fromJson(obj.toString(), HashMap.class);
@@ -1073,15 +1067,14 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
             }
         };
 
-        String customType = call.argument("customType");
+        String name = call.argument("name");
         HashMap metadataMap= call.argument("metadata");
         JSONObject metadataJson = jsonForMap(metadataMap);        
-        if (call.hasArgument("location") && call.argument("location") != null) {
-            HashMap locationMap = (HashMap)call.argument("location");
-            Location location = locationForMap(locationMap);
-            Radar.sendEvent(customType, location, metadataJson, callback);
+        if (call.hasArgument("revenue") && call.argument("revenue") != null) {
+            double revenue = (Double)call.argument("revenue");
+            Radar.logConversion(name, revenue, metadataJson, callback);
         } else {
-            Radar.sendEvent(customType, metadataJson, callback);
+            Radar.logConversion(name, metadataJson, callback);
         }
     }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -49,7 +49,7 @@ android {
     }
 
     dependencies {
-        implementation 'io.radar:sdk:3.5.9'
+        implementation 'io.radar:sdk:3.8.12'
     }
 }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -50,6 +50,7 @@ android {
 
     dependencies {
         implementation 'io.radar:sdk:3.8.12'
+        implementation "com.google.android.play:integrity:1.2.0"
     }
 }
 

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,8 @@
     <application
         android:name=".MainApplication"
         android:label="flutter_radar_example"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"

--- a/example/android/app/src/main/res/xml/network_security_config.xml
+++ b/example/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="true">api-verified.radar.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">15ktYXSSU2llpy7YyCgeqUKDBkjcimK/weUcec960sI=</pin>
+            <pin digest="SHA-256">15ktYXSSU2llpy7YyCgeqUKDBkjcimK/weUcec960sI=</pin>
+        </pin-set>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="true">api-verified.radar-staging.com</domain>
+        <pin-set>
+            <pin digest="SHA-256">09MICn++JSUz2tk36fH+5qiuUAbbxx4JzrAHR3QHu/I=</pin>
+            <pin digest="SHA-256">09MICn++JSUz2tk36fH+5qiuUAbbxx4JzrAHR3QHu/I=</pin>
+        </pin-set>
+    </domain-config>
+</network-security-config>

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -54,5 +54,29 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<false/>
+		<key>NSPinnedDomains</key>
+		<dict>
+			<key>api-verified.radar.io</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSPinnedLeafIdentities</key>
+				<array>
+					<dict>
+						<key>SPKI-SHA256-BASE64</key>
+						<string>15ktYXSSU2llpy7YyCgeqUKDBkjcimK/weUcec960sI=</string>
+					</dict>
+					<dict>
+						<key>SPKI-SHA256-BASE64</key>
+						<string>15ktYXSSU2llpy7YyCgeqUKDBkjcimK/weUcec960sI=</string>
+					</dict>
+				</array>
+			</dict>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -355,6 +355,14 @@ class _MyAppState extends State<MyApp> {
               },
               child: Text('trackVerifiedToken'),
             ),
+            ElevatedButton(
+              style: raisedButtonStyle,
+              onPressed: () async {
+                bool? resp = await Radar.isUsingRemoteTrackingOptions();
+                print("isUsingRemoteTrackingOptions: $resp");
+              },
+              child: Text('isUsingRemoteTrackingOptions'),
+            ),
           ]),
         )
       ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -200,17 +200,13 @@ class _MyAppState extends State<MyApp> {
             ElevatedButton(
               style: raisedButtonStyle,
               onPressed: () async {
-                var resp = await Radar.sendEvent(
-                  customType: "in_app_purchase",
-                  location: {
-                    "latitude": 35.0,
-                    "longitude": -75.0
-                  },
-                  metadata: {"price": "150USD"}
-                );
-                print("sendEvent: $resp");
+                var resp = await Radar.logConversion(
+                    name: "in_app_purchase",
+                    revenue: 0.2,
+                    metadata: {"price": "150USD"});
+                print("logConversion: $resp");
               },
-              child: Text('sendEvent'),
+              child: Text('logConversion'),
             ),
             ElevatedButton(
               style: raisedButtonStyle,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -343,9 +343,17 @@ class _MyAppState extends State<MyApp> {
               style: raisedButtonStyle,
               onPressed: () async {
                 Map? resp = await Radar.trackVerified();
-                print("getMatrix: $resp");
+                print("trackVerified: $resp");
               },
               child: Text('trackVerified'),
+            ),
+            ElevatedButton(
+              style: raisedButtonStyle,
+              onPressed: () async {
+                Map? resp = await Radar.trackVerifiedToken();
+                print("trackVerifiedToken: $resp");
+              },
+              child: Text('trackVerifiedToken'),
             ),
           ]),
         )

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -363,6 +363,21 @@ class _MyAppState extends State<MyApp> {
               },
               child: Text('isUsingRemoteTrackingOptions'),
             ),
+            ElevatedButton(
+              style: raisedButtonStyle,
+              onPressed: () async {
+                Map? resp = await Radar.validateAddress({
+                  "city": "NEW YORK",
+                  "stateCode": "NY",
+                  "postalCode": "10003",
+                  "countryCode": "US",
+                  "street": "BROADWAY",
+                  "number": "841",
+                });
+                print("validateAddress: $resp");
+              },
+              child: Text('validateAddress'),
+            ),
           ]),
         )
       ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -238,7 +238,8 @@ class _MyAppState extends State<MyApp> {
                   },
                   limit: 10,
                   layers: ['address', 'street'],
-                  country: 'US'
+                  country: 'US',
+                  expandUnits: false
                 );
                 print("autocomplete: $resp");
               },
@@ -337,7 +338,15 @@ class _MyAppState extends State<MyApp> {
                 print(location);
               },
               child: Text('getLocation()'),
-            )
+            ),
+            ElevatedButton(
+              style: raisedButtonStyle,
+              onPressed: () async {
+                Map? resp = await Radar.trackVerified();
+                print("getMatrix: $resp");
+              },
+              child: Text('trackVerified'),
+            ),
           ]),
         )
       ),

--- a/ios/Classes/RadarFlutterPlugin.m
+++ b/ios/Classes/RadarFlutterPlugin.m
@@ -113,6 +113,8 @@
         // do nothing
     } else if ([@"trackVerified" isEqualToString:call.method]) {
         [self trackVerified:call withResult:result];    
+    } else if ([@"trackVerifiedToken" isEqualToString:call.method]) {
+        [self trackVerifiedToken:call withResult:result];    
     } else if ([@"attachListeners" isEqualToString:call.method]) {
         [self attachListeners:call withResult:result];
     } else if ([@"detachListeners" isEqualToString:call.method]) {
@@ -902,6 +904,19 @@
     };
 
     [Radar trackVerifiedWithCompletionHandler:completionHandler];
+}
+
+- (void)trackVerifiedToken:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    RadarTrackTokenCompletionHandler completionHandler = ^(RadarStatus status, NSString* token) {
+        if (status == RadarStatusSuccess) {
+            NSMutableDictionary *dict = [NSMutableDictionary new];
+            [dict setObject:[Radar stringForStatus:status] forKey:@"status"];
+            [dict setObject:token forKey:@"token"];
+            result(dict);
+        }
+    };
+
+    [Radar trackVerifiedTokenWithCompletionHandler:completionHandler];
 }
 
 -(void)attachListeners:(FlutterMethodCall *)call withResult:(FlutterResult)result {    

--- a/ios/Classes/RadarFlutterPlugin.m
+++ b/ios/Classes/RadarFlutterPlugin.m
@@ -117,6 +117,8 @@
         [self trackVerifiedToken:call withResult:result];    
     } else if ([@"isUsingRemoteTrackingOptions" isEqualToString:call.method]) {
         [self isUsingRemoteTrackingOptions:call withResult:result];    
+    } else if ([@"validateAddress" isEqualToString:call.method]) {
+        [self validateAddress:call withResult:result];    
     } else if ([@"attachListeners" isEqualToString:call.method]) {
         [self attachListeners:call withResult:result];
     } else if ([@"detachListeners" isEqualToString:call.method]) {
@@ -924,6 +926,24 @@
     };
 
     [Radar trackVerifiedTokenWithCompletionHandler:completionHandler];
+}
+
+- (void)validateAddress:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+  RadarValidateAddressCompletionHandler completionHandler = ^(RadarStatus status, RadarAddress * _Nullable address, RadarAddressVerificationStatus verificationStatus) {
+      NSMutableDictionary *dict = [NSMutableDictionary new];
+      [dict setObject:[Radar stringForStatus:status] forKey:@"status"];
+      if (address) {
+        [dict setObject:[address dictionaryValue] forKey:@"address"];
+      }
+      [dict setObject:[Radar stringForVerificationStatus:verificationStatus] forKey:@"verificationStatus"];
+      result(dict);
+  };
+
+  NSDictionary *argsDict = call.arguments;
+
+  NSDictionary *addressDict = argsDict[@"address"];
+  RadarAddress *address = [RadarAddress addressFromObject:addressDict];
+  [Radar validateAddress:address completionHandler:completionHandler];
 }
 
 -(void)attachListeners:(FlutterMethodCall *)call withResult:(FlutterResult)result {    

--- a/ios/Classes/RadarFlutterPlugin.m
+++ b/ios/Classes/RadarFlutterPlugin.m
@@ -111,6 +111,8 @@
         [self getMatrix:call withResult:result];        
     } else if ([@"setForegroundServiceOptions" isEqualToString:call.method]) {
         // do nothing
+    } else if ([@"trackVerified" isEqualToString:call.method]) {
+        [self trackVerified:call withResult:result];    
     } else if ([@"attachListeners" isEqualToString:call.method]) {
         [self attachListeners:call withResult:result];
     } else if ([@"detachListeners" isEqualToString:call.method]) {
@@ -879,6 +881,27 @@
         }
         result(dict);
     }];    
+}
+
+- (void)trackVerified:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    RadarTrackCompletionHandler completionHandler = ^(RadarStatus status, CLLocation *location, NSArray<RadarEvent *> *events, RadarUser *user) {
+        if (status == RadarStatusSuccess) {
+            NSMutableDictionary *dict = [NSMutableDictionary new];
+            [dict setObject:[Radar stringForStatus:status] forKey:@"status"];
+            if (location) {
+                [dict setObject:[Radar dictionaryForLocation:location] forKey:@"location"];
+            }
+            if (events) {
+                [dict setObject:[RadarEvent arrayForEvents:events] forKey:@"events"];
+            }
+            if (user) {
+                [dict setObject:[user dictionaryValue] forKey:@"user"];
+            }
+            result(dict);
+        }
+    };
+
+    [Radar trackVerifiedWithCompletionHandler:completionHandler];
 }
 
 -(void)attachListeners:(FlutterMethodCall *)call withResult:(FlutterResult)result {    

--- a/ios/Classes/RadarFlutterPlugin.m
+++ b/ios/Classes/RadarFlutterPlugin.m
@@ -670,15 +670,24 @@
     }
     NSArray *layers = [argsDict[@"layers"] isKindOfClass:[NSNull class]] ? nil : argsDict[@"layers"];
     NSString *country = [argsDict[@"country"] isKindOfClass:[NSNull class]] ? nil : argsDict[@"country"];
-
-    [Radar autocompleteQuery:query near:near layers:layers limit:limit country:country completionHandler:^(RadarStatus status, NSArray<RadarAddress *> * _Nullable addresses) {
+    
+    RadarGeocodeCompletionHandler completionHandler = ^(RadarStatus status, NSArray<RadarAddress *> * _Nullable addresses) {
         NSMutableDictionary *dict = [NSMutableDictionary new];
         [dict setObject:[Radar stringForStatus:status] forKey:@"status"];
         if (addresses) {
             [dict setObject:[RadarAddress arrayForAddresses:addresses] forKey:@"addresses"];
         }
         result(dict);
-    }];
+    };
+
+    
+    NSNumber *expandUnitsNumber = argsDict[@"expandUnits"];
+    if (expandUnitsNumber != nil && [expandUnitsNumber isKindOfClass:[NSNumber class]]) {
+        BOOL expandUnits = [expandUnitsNumber boolValue];
+        [Radar autocompleteQuery:query near:near layers:layers limit:limit country:country expandUnits:expandUnits completionHandler:completionHandler];
+    } else {
+        [Radar autocompleteQuery:query near:near layers:layers limit:limit country:country completionHandler:completionHandler];
+    }
 }
 
 - (void)geocode:(FlutterMethodCall *)call withResult:(FlutterResult)result {

--- a/ios/Classes/RadarFlutterPlugin.m
+++ b/ios/Classes/RadarFlutterPlugin.m
@@ -115,6 +115,8 @@
         [self trackVerified:call withResult:result];    
     } else if ([@"trackVerifiedToken" isEqualToString:call.method]) {
         [self trackVerifiedToken:call withResult:result];    
+    } else if ([@"isUsingRemoteTrackingOptions" isEqualToString:call.method]) {
+        [self isUsingRemoteTrackingOptions:call withResult:result];    
     } else if ([@"attachListeners" isEqualToString:call.method]) {
         [self attachListeners:call withResult:result];
     } else if ([@"detachListeners" isEqualToString:call.method]) {
@@ -367,6 +369,11 @@
 - (void)isTracking:(FlutterMethodCall *)call withResult:(FlutterResult)result {
     BOOL isTracking = [Radar isTracking];
     result(@(isTracking));
+}
+
+- (void)isUsingRemoteTrackingOptions:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    BOOL isRemoteTracking = [Radar isUsingRemoteTrackingOptions];
+    result(@(isRemoteTracking));
 }
 
 - (void)getTrackingOptions:(FlutterMethodCall *)call withResult:(FlutterResult)result {

--- a/ios/flutter_radar.podspec
+++ b/ios/flutter_radar.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'RadarSDK', '3.5.9'
+  s.dependency 'RadarSDK', '3.8.9'
   s.platform = :ios, '10.0'
   s.static_framework = true
 

--- a/ios/flutter_radar.podspec
+++ b/ios/flutter_radar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'flutter_radar'
-  s.version          = '3.1.6'
+  s.version          = '3.2.0'
   s.summary          = 'Flutter package for Radar, the leading geofencing and location tracking platform'
   s.description      = 'Flutter package for Radar, the leading geofencing and location tracking platform'
   s.homepage         = 'http://example.com'

--- a/lib/flutter_radar.dart
+++ b/lib/flutter_radar.dart
@@ -296,10 +296,10 @@ class Radar {
   }
 
   static Future<Map?> autocomplete(
-      {String? query, Map<String, dynamic>? near, int? limit, String? country, List? layers}) async {
+      {String? query, Map<String, dynamic>? near, int? limit, String? country, List? layers, bool? expandUnits}) async {
     try {
       return await _channel.invokeMethod(
-          'autocomplete', {'query': query, 'near': near, 'limit': limit, 'country': country, 'layers': layers});
+          'autocomplete', {'query': query, 'near': near, 'limit': limit, 'country': country, 'layers': layers, 'expandUnits': expandUnits});
     } on PlatformException catch (e) {
       print(e);
       return {'error': e.code};
@@ -389,6 +389,17 @@ class Radar {
     } on PlatformException catch (e) {
       print(e);
     }
+  }
+
+  static Future<Map?> trackVerified() async {
+    try {
+      return await _channel
+          .invokeMethod('trackVerified');
+    } on PlatformException catch (e) {
+      print(e);
+      return {'error': e.code};
+    }
+    
   }
 
   static onLocation(Function(Map res) callback) async {

--- a/lib/flutter_radar.dart
+++ b/lib/flutter_radar.dart
@@ -22,12 +22,6 @@ void callbackDispatcher() {
 class Radar {
   static const MethodChannel _channel = const MethodChannel('flutter_radar');
 
-  static Function(Map res)? _eventsCallback;
-  static Function(Map res)? _locationCallback;
-  static Function(Map res)? _clientLocationCallback;
-  static Function(Map res)? _errorCallback;
-  static Function(Map res)? _logCallback;
-
   static Future initialize(String publishableKey) async {
     try {
       await _channel.invokeMethod('initialize', {
@@ -360,10 +354,13 @@ class Radar {
     }
   }
 
-  static Future<Map?> sendEvent({required String customType, Map<String, dynamic>? location, required Map<String, dynamic> metadata}) async {
+  static Future<Map?> logConversion(
+      {required String name,
+      double? revenue,
+      required Map<String, dynamic> metadata}) async {
     try {
-      return await _channel
-          .invokeMethod('sendEvent', {'customType': customType, 'location': location, 'metadata': metadata});
+      return await _channel.invokeMethod('logConversion',
+          {'name': name, 'revenue': revenue, 'metadata': metadata});
     } on PlatformException catch (e) {
       print(e);
       return {'error': e.code};

--- a/lib/flutter_radar.dart
+++ b/lib/flutter_radar.dart
@@ -402,6 +402,17 @@ class Radar {
     
   }
 
+  static Future<Map?> trackVerifiedToken() async {
+    try {
+      return await _channel
+          .invokeMethod('trackVerifiedToken');
+    } on PlatformException catch (e) {
+      print(e);
+      return {'error': e.code};
+    }
+    
+  }
+
   static onLocation(Function(Map res) callback) async {
     try {
       final CallbackHandle handle = PluginUtilities.getCallbackHandle(callback)!;

--- a/lib/flutter_radar.dart
+++ b/lib/flutter_radar.dart
@@ -117,14 +117,6 @@ class Radar {
     }
   }
 
-  static Future setAdIdEnabled(bool enabled) async {
-    try {
-      await _channel.invokeMethod('setAdIdEnabled', {'enabled': enabled});
-    } on PlatformException catch (e) {
-      print(e);
-    }
-  }
-
   static Future<Map?> getLocation([String? accuracy]) async {
     try {
       return await _channel.invokeMethod('getLocation', {'accuracy': accuracy});

--- a/lib/flutter_radar.dart
+++ b/lib/flutter_radar.dart
@@ -399,7 +399,6 @@ class Radar {
       print(e);
       return {'error': e.code};
     }
-    
   }
 
   static Future<Map?> trackVerifiedToken() async {
@@ -410,7 +409,10 @@ class Radar {
       print(e);
       return {'error': e.code};
     }
-    
+  }
+
+  static Future<bool?> isUsingRemoteTrackingOptions() async {
+    return await _channel.invokeMethod('isUsingRemoteTrackingOptions');
   }
 
   static onLocation(Function(Map res) callback) async {

--- a/lib/flutter_radar.dart
+++ b/lib/flutter_radar.dart
@@ -415,6 +415,16 @@ class Radar {
     return await _channel.invokeMethod('isUsingRemoteTrackingOptions');
   }
 
+  static Future<Map?> validateAddress(Map address) async {
+    try {
+      return await _channel
+          .invokeMethod('validateAddress', {'address': address});
+    } on PlatformException catch (e) {
+      print(e);
+      return {'error': e.code};
+    }
+  }
+
   static onLocation(Function(Map res) callback) async {
     try {
       final CallbackHandle handle = PluginUtilities.getCallbackHandle(callback)!;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_radar
 description: Flutter package for Radar, the leading geofencing and location tracking platform
-version: 3.1.7
+version: 3.1.8
 homepage: https://github.com/radarlabs/flutter-radar
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_radar
 description: Flutter package for Radar, the leading geofencing and location tracking platform
-version: 3.1.8
+version: 3.2.0
 homepage: https://github.com/radarlabs/flutter-radar
 
 environment:


### PR DESCRIPTION
- Bump iOS version from 3.5.9 to 3.8.9
- Bump android version from 3.5.9 to 3.8.12
- remove `setAdIdEnabled`
- rename `sendEvent` to `logConversion` and add `revenue` param
- add `trackVerified`
- add `trackVerifiedToken`
- add `isUsingRemoteTrackingOptions`
- update `autocompleteQuery` with param add `expandUnits`
- add `validateAddress`
- add `App Attest` to ios example
- add `Play Integrity API` to android example
- update example project