### PR TITLE
Support gradle 8+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'io.radar.flutter'
     compileSdkVersion 31
 
     defaultConfig {


### PR DESCRIPTION
Add `namespace` to `build.gradle` to support building in Android with gradle 8+. Otherwise build fails.