### PR TITLE
Foreground location tracking

### DIFF
--- a/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
+++ b/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
@@ -76,7 +76,7 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
     private static final String TAG = "RadarFlutterPlugin";
     private static final String CALLBACK_DISPATCHER_HANDLE_KEY = "callbackDispatcherHandle";
     private static MethodChannel sBackgroundChannel;
-    private static MethodChannel channel;
+    private MethodChannel channel;
 
     private static final Object lock = new Object();
 
@@ -108,10 +108,10 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
     
     @Override
     public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
-        Radar.setReceiver(new RadarFlutterReceiver());
         mContext = binding.getApplicationContext();
-        RadarFlutterPlugin.channel = new MethodChannel(binding.getFlutterEngine().getDartExecutor(), "flutter_radar");
-        RadarFlutterPlugin.channel.setMethodCallHandler(this);
+        channel = new MethodChannel(binding.getFlutterEngine().getDartExecutor(), "flutter_radar");
+        Radar.setReceiver(new RadarFlutterReceiver(channel));
+        channel.setMethodCallHandler(this);
     }
 
     @Override
@@ -328,7 +328,7 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
         editor.putString("x_platform_sdk_version", "3.9.1");
         editor.apply();
         Radar.initialize(mContext, publishableKey);
-        Radar.setReceiver(new RadarFlutterReceiver());
+        Radar.setReceiver(new RadarFlutterReceiver(channel));
         result.success(true);
     }
 
@@ -1308,6 +1308,12 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
     }
 
     public static class RadarFlutterReceiver extends RadarReceiver {
+
+        private MethodChannel channel;
+
+        RadarFlutterReceiver(MethodChannel channel) {
+            this.channel = channel;
+        }
 
         @Override
         public void onEventsReceived(Context context, RadarEvent[] events, RadarUser user) {

--- a/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
+++ b/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
@@ -76,6 +76,7 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
     private static final String TAG = "RadarFlutterPlugin";
     private static final String CALLBACK_DISPATCHER_HANDLE_KEY = "callbackDispatcherHandle";
     private static MethodChannel sBackgroundChannel;
+    private static MethodChannel channel;
 
     private static final Object lock = new Object();
 
@@ -109,8 +110,8 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
     public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
         Radar.setReceiver(new RadarFlutterReceiver());
         mContext = binding.getApplicationContext();
-        MethodChannel channel = new MethodChannel(binding.getFlutterEngine().getDartExecutor(), "flutter_radar");
-        channel.setMethodCallHandler(this);
+        RadarFlutterPlugin.channel = new MethodChannel(binding.getFlutterEngine().getDartExecutor(), "flutter_radar");
+        RadarFlutterPlugin.channel.setMethodCallHandler(this);
     }
 
     @Override
@@ -327,6 +328,7 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
         editor.putString("x_platform_sdk_version", "3.9.1");
         editor.apply();
         Radar.initialize(mContext, publishableKey);
+        Radar.setReceiver(new RadarFlutterReceiver());
         result.success(true);
     }
 
@@ -1346,28 +1348,31 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
                 SharedPreferences sharedPrefs = context.getSharedPreferences(TAG, Context.MODE_PRIVATE);
                 long callbackHandle = sharedPrefs.getLong("location", 0L);
 
-                if (callbackHandle == 0L) {
-                    Log.e(TAG, "callback handle is empty");
-                    return;
-                }
-
-                RadarFlutterPlugin.initializeBackgroundEngine(context);
-                
                 JSONObject obj = new JSONObject();
                 obj.put("location", Radar.jsonForLocation(location));
                 obj.put("user", user.toJson());
 
                 HashMap<String, Object> res = new Gson().fromJson(obj.toString(), HashMap.class);
-                synchronized(lock) {
-                    final ArrayList args = new ArrayList();
-                    args.add(callbackHandle);
-                    args.add(res);
-                    runOnMainThread(new Runnable() {
-                        @Override
-                        public void run() {
-                            sBackgroundChannel.invokeMethod("", args);
-                        }
-                    });
+
+                final ArrayList locationArgs = new ArrayList();
+                locationArgs.add(0);
+                locationArgs.add(res);
+                channel.invokeMethod("location", locationArgs);
+                
+                if (callbackHandle != 0L) {
+                    RadarFlutterPlugin.initializeBackgroundEngine(context);
+
+                    synchronized(lock) {
+                        final ArrayList args = new ArrayList();
+                        args.add(callbackHandle);
+                        args.add(res);
+                        runOnMainThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                sBackgroundChannel.invokeMethod("", args);
+                            }
+                        });
+                    }
                 }
             } catch (Exception e) {
                 Log.e(TAG, e.toString());
@@ -1378,12 +1383,6 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
             try {
                 SharedPreferences sharedPrefs = context.getSharedPreferences(TAG, Context.MODE_PRIVATE);
                 long callbackHandle = sharedPrefs.getLong("clientLocation", 0L);
-
-                if (callbackHandle == 0L) {
-                    return;
-                }
-
-                RadarFlutterPlugin.initializeBackgroundEngine(context);
                 
                 JSONObject obj = new JSONObject();
                 obj.put("location", Radar.jsonForLocation(location));
@@ -1391,16 +1390,26 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
                 obj.put("source", source.toString());
 
                 HashMap<String, Object> res = new Gson().fromJson(obj.toString(), HashMap.class);
-                synchronized(lock) {
-                    final ArrayList args = new ArrayList();
-                    args.add(callbackHandle);
-                    args.add(res);
-                    runOnMainThread(new Runnable() {
-                        @Override
-                        public void run() {
-                            sBackgroundChannel.invokeMethod("", args);
-                        }
-                    });
+
+                final ArrayList clientLocationArgs = new ArrayList();
+                clientLocationArgs.add(0);
+                clientLocationArgs.add(res);
+                channel.invokeMethod("clientLocation", clientLocationArgs);
+
+                if (callbackHandle != 0L) {
+                    RadarFlutterPlugin.initializeBackgroundEngine(context);
+
+                    synchronized(lock) {
+                        final ArrayList args = new ArrayList();
+                        args.add(callbackHandle);
+                        args.add(res);
+                        runOnMainThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                sBackgroundChannel.invokeMethod("", args);
+                            }
+                        });
+                    }
                 }
             } catch (Exception e) {
                 Log.e(TAG, e.toString());
@@ -1510,6 +1519,7 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
     }
 
     public void attachListeners(MethodCall call, Result result) {
+        Log.e(TAG, "attaching listeners");
         SharedPreferences sharedPrefs = mContext.getSharedPreferences(TAG, Context.MODE_PRIVATE);
         long callbackDispatcherHandle = ((Number)call.argument("callbackDispatcherHandle")).longValue();
         sharedPrefs.edit().putLong(CALLBACK_DISPATCHER_HANDLE_KEY, callbackDispatcherHandle).commit();

--- a/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
+++ b/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
@@ -1525,7 +1525,6 @@ public class RadarFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
     }
 
     public void attachListeners(MethodCall call, Result result) {
-        Log.e(TAG, "attaching listeners");
         SharedPreferences sharedPrefs = mContext.getSharedPreferences(TAG, Context.MODE_PRIVATE);
         long callbackDispatcherHandle = ((Number)call.argument("callbackDispatcherHandle")).longValue();
         sharedPrefs.edit().putLong(CALLBACK_DISPATCHER_HANDLE_KEY, callbackDispatcherHandle).commit();

--- a/ios/Classes/RadarFlutterPlugin.m
+++ b/ios/Classes/RadarFlutterPlugin.m
@@ -1027,6 +1027,7 @@
     self.sBackgroundFlutterEngine = sBackgroundFlutterEngine;
 
     FlutterMethodChannel *backgroundChannel = [FlutterMethodChannel methodChannelWithName:@"flutter_radar_background" binaryMessenger:[sBackgroundFlutterEngine binaryMessenger]];
+    self.backgroundChannel = backgroundChannel;
     [self.sBackgroundFlutterEngine runWithEntrypoint:callbackInfo.callbackName libraryURI: callbackInfo.callbackLibraryPath];
     result(nil);
 }

--- a/ios/Classes/RadarFlutterPlugin.m
+++ b/ios/Classes/RadarFlutterPlugin.m
@@ -1070,12 +1070,12 @@
     NSDictionary *dict = @{@"location": [Radar dictionaryForLocation:location], @"user": [user dictionaryValue]};
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     NSInteger callbackHandle = [userDefaults integerForKey:@"location"];
-    if (callbackHandle == 0) {
-        return;
-    }
     NSArray* args = @[[NSNumber numberWithInteger:callbackHandle], dict];
     if (self.channel != nil) {
         [self.channel invokeMethod:@"location" arguments:args];
+    }
+    if (callbackHandle == 0) {
+        return;
     }
     [self.backgroundChannel invokeMethod:@"" arguments:args];
 }
@@ -1084,12 +1084,12 @@
     NSDictionary *dict = @{@"location": [Radar dictionaryForLocation:location], @"stopped": @(stopped), @"source": [Radar stringForLocationSource:source]};
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     NSInteger callbackHandle = [userDefaults integerForKey:@"clientLocation"];
-    if (callbackHandle == 0) {
-        return;
-    }
     NSArray* args = @[[NSNumber numberWithInteger:callbackHandle], dict];
     if (self.channel != nil) {
         [self.channel invokeMethod:@"clientLocation" arguments:args];
+    }
+    if (callbackHandle == 0) {
+        return;
     }
     [self.backgroundChannel invokeMethod:@"" arguments:args];
 }

--- a/ios/Classes/RadarFlutterPlugin.m
+++ b/ios/Classes/RadarFlutterPlugin.m
@@ -1074,7 +1074,9 @@
         return;
     }
     NSArray* args = @[[NSNumber numberWithInteger:callbackHandle], dict];
-    [self.channel invokeMethod:@"location" arguments:args];
+    if (self.channel != nil) {
+        [self.channel invokeMethod:@"location" arguments:args];
+    }
     [self.backgroundChannel invokeMethod:@"" arguments:args];
 }
 
@@ -1086,7 +1088,9 @@
         return;
     }
     NSArray* args = @[[NSNumber numberWithInteger:callbackHandle], dict];
-    [self.channel invokeMethod:@"clientLocation" arguments:args];
+    if (self.channel != nil) {
+        [self.channel invokeMethod:@"clientLocation" arguments:args];
+    }
     [self.backgroundChannel invokeMethod:@"" arguments:args];
 }
 

--- a/ios/Classes/RadarFlutterPlugin.m
+++ b/ios/Classes/RadarFlutterPlugin.m
@@ -1027,9 +1027,7 @@
     self.sBackgroundFlutterEngine = sBackgroundFlutterEngine;
 
     FlutterMethodChannel *backgroundChannel = [FlutterMethodChannel methodChannelWithName:@"flutter_radar_background" binaryMessenger:[sBackgroundFlutterEngine binaryMessenger]];
-    self.backgroundChannel = backgroundChannel;
-
-    [self.sBackgroundFlutterEngine runWithEntrypoint:callbackInfo.callbackName libraryURI: callbackInfo.callbackLibraryPath] ;    
+    [self.sBackgroundFlutterEngine runWithEntrypoint:callbackInfo.callbackName libraryURI: callbackInfo.callbackLibraryPath];
     result(nil);
 }
 
@@ -1075,6 +1073,7 @@
         return;
     }
     NSArray* args = @[[NSNumber numberWithInteger:callbackHandle], dict];
+    [self.channel invokeMethod:@"location" arguments:args];
     [self.backgroundChannel invokeMethod:@"" arguments:args];
 }
 
@@ -1086,6 +1085,7 @@
         return;
     }
     NSArray* args = @[[NSNumber numberWithInteger:callbackHandle], dict];
+    [self.channel invokeMethod:@"clientLocation" arguments:args];
     [self.backgroundChannel invokeMethod:@"" arguments:args];
 }
 

--- a/lib/flutter_radar.dart
+++ b/lib/flutter_radar.dart
@@ -20,16 +20,39 @@ void callbackDispatcher() {
   });
 }
 
+typedef LocationCallback = void Function(Map<dynamic, dynamic> locationEvent);
+typedef ClientLocationCallback = void Function(
+  Map<dynamic, dynamic> locationEvent,
+);
+
 class Radar {
   static const MethodChannel _channel = const MethodChannel('flutter_radar');
+
+  static LocationCallback? foregroundLocationCallback;
+  static ClientLocationCallback? foregroundClientLocationCallback;
 
   static Future initialize(String publishableKey) async {
     try {
       await _channel.invokeMethod('initialize', {
         'publishableKey': publishableKey,
       });
+      _channel.setMethodCallHandler(_handleMethodCall);
     } on PlatformException catch (e) {
       print(e);
+    }
+  }
+
+  static Future<Object?> _handleMethodCall(MethodCall call) async {
+    final args = call.arguments;
+    switch (call.method) {
+      case 'location':
+        foregroundLocationCallback?.call(args[1] as Map<dynamic, dynamic>);
+        break;
+      case 'clientLocation':
+        foregroundClientLocationCallback?.call(
+          args[1] as Map<dynamic, dynamic>,
+        );
+        break;
     }
   }
 
@@ -491,6 +514,17 @@ class Radar {
     }
   }
 
+  static onLocationForeground(LocationCallback callback) {
+    if (foregroundLocationCallback != null) {
+      throw RadarExistingCallbackException();
+    }
+    foregroundLocationCallback = callback;
+  }
+
+  static offLocationForeground() {
+    foregroundLocationCallback = null;
+  }
+
   static onLocation(Function(Map res) callback) async {
     try {
       final CallbackHandle handle =
@@ -508,6 +542,17 @@ class Radar {
     } on PlatformException catch (e) {
       print(e);
     }
+  }
+
+  static void onClientLocationForeground(ClientLocationCallback callback) {
+    if (foregroundClientLocationCallback != null) {
+      throw RadarExistingCallbackException();
+    }
+    foregroundClientLocationCallback = callback;
+  }
+
+  static offClientLocationForeground() {
+    foregroundClientLocationCallback = null;
   }
 
   static onClientLocation(Function(Map res) callback) async {
@@ -608,49 +653,49 @@ class Radar {
   }
 
   static Map<String, dynamic> presetContinuousIOS = {
-  "desiredStoppedUpdateInterval": 30,
-  "desiredMovingUpdateInterval": 30,
-  "desiredSyncInterval": 20,
-  "desiredAccuracy":'high',
-  "stopDuration": 140,
-  "stopDistance": 70,
-  "replay": 'none',
-  "useStoppedGeofence": false,
-  "showBlueBar": true,
-  "startTrackingAfter": null,
-  "stopTrackingAfter": null,
-  "stoppedGeofenceRadius": 0,
-  "useMovingGeofence": false,
-  "movingGeofenceRadius": 0,
-  "syncGeofences": true,
-  "useVisits": false,
-  "useSignificantLocationChanges": false,
-  "beacons": false,
-  "sync": 'all',
-};
+    "desiredStoppedUpdateInterval": 30,
+    "desiredMovingUpdateInterval": 30,
+    "desiredSyncInterval": 20,
+    "desiredAccuracy": 'high',
+    "stopDuration": 140,
+    "stopDistance": 70,
+    "replay": 'none',
+    "useStoppedGeofence": false,
+    "showBlueBar": true,
+    "startTrackingAfter": null,
+    "stopTrackingAfter": null,
+    "stoppedGeofenceRadius": 0,
+    "useMovingGeofence": false,
+    "movingGeofenceRadius": 0,
+    "syncGeofences": true,
+    "useVisits": false,
+    "useSignificantLocationChanges": false,
+    "beacons": false,
+    "sync": 'all',
+  };
 
-  static Map<String, dynamic> presetContinuousAndroid =  {
-  "desiredStoppedUpdateInterval": 30,
-  "fastestStoppedUpdateInterval": 30,
-  "desiredMovingUpdateInterval": 30,
-  "fastestMovingUpdateInterval": 30,
-  "desiredSyncInterval": 20,
-  "desiredAccuracy": 'high',
-  "stopDuration": 140,
-  "stopDistance": 70,
-  "replay": 'none',
-  "sync": 'all',
-  "useStoppedGeofence": false,
-  "stoppedGeofenceRadius": 0,
-  "useMovingGeofence": false,
-  "movingGeofenceRadius": 0,
-  "syncGeofences": true,
-  "syncGeofencesLimit": 0,
-  "foregroundServiceEnabled": true,
-  "beacons": false,
-  "startTrackingAfter": null,
-  "stopTrackingAfter": null,
-};
+  static Map<String, dynamic> presetContinuousAndroid = {
+    "desiredStoppedUpdateInterval": 30,
+    "fastestStoppedUpdateInterval": 30,
+    "desiredMovingUpdateInterval": 30,
+    "fastestMovingUpdateInterval": 30,
+    "desiredSyncInterval": 20,
+    "desiredAccuracy": 'high',
+    "stopDuration": 140,
+    "stopDistance": 70,
+    "replay": 'none',
+    "sync": 'all',
+    "useStoppedGeofence": false,
+    "stoppedGeofenceRadius": 0,
+    "useMovingGeofence": false,
+    "movingGeofenceRadius": 0,
+    "syncGeofences": true,
+    "syncGeofencesLimit": 0,
+    "foregroundServiceEnabled": true,
+    "beacons": false,
+    "startTrackingAfter": null,
+    "stopTrackingAfter": null,
+  };
 
   static Map<String, dynamic> presetResponsiveIOS = {
     "desiredStoppedUpdateInterval": 0,
@@ -698,54 +743,61 @@ class Radar {
   };
 
   static Map<String, dynamic> presetEfficientIOS = {
-  "desiredStoppedUpdateInterval": 0,
-  "desiredMovingUpdateInterval": 0,
-  "desiredSyncInterval": 0,
-  "desiredAccuracy": "medium",
-  "stopDuration": 0,
-  "stopDistance": 0,
-  "replay": 'stops',
-  "useStoppedGeofence": false,
-  "showBlueBar": false,
-  "startTrackingAfter": null,
-  "stopTrackingAfter": null,
-  "stoppedGeofenceRadius": 0,
-  "useMovingGeofence": false,
-  "movingGeofenceRadius": 0,
-  "syncGeofences": true,
-  "useVisits": true,
-  "useSignificantLocationChanges": false,
-  "beacons": false,
-  "sync": 'all',
-};
+    "desiredStoppedUpdateInterval": 0,
+    "desiredMovingUpdateInterval": 0,
+    "desiredSyncInterval": 0,
+    "desiredAccuracy": "medium",
+    "stopDuration": 0,
+    "stopDistance": 0,
+    "replay": 'stops',
+    "useStoppedGeofence": false,
+    "showBlueBar": false,
+    "startTrackingAfter": null,
+    "stopTrackingAfter": null,
+    "stoppedGeofenceRadius": 0,
+    "useMovingGeofence": false,
+    "movingGeofenceRadius": 0,
+    "syncGeofences": true,
+    "useVisits": true,
+    "useSignificantLocationChanges": false,
+    "beacons": false,
+    "sync": 'all',
+  };
 
-  static Map<String, dynamic> presetEfficientAndroid ={
-  "desiredStoppedUpdateInterval": 3600,
-  "fastestStoppedUpdateInterval": 1200,
-  "desiredMovingUpdateInterval": 1200,
-  "fastestMovingUpdateInterval": 360,
-  "desiredSyncInterval": 140,
-  "desiredAccuracy": 'medium',
-  "stopDuration": 140,
-  "stopDistance": 70,
-  "replay": 'stops',
-  "sync": 'all',
-  "useStoppedGeofence": false,
-  "stoppedGeofenceRadius": 0,
-  "useMovingGeofence": false,
-  "movingGeofenceRadius": 0,
-  "syncGeofences": true,
-  "syncGeofencesLimit": 10,
-  "foregroundServiceEnabled": false,
-  "beacons": false,
-  "startTrackingAfter": null,
-  "stopTrackingAfter": null,
-};
+  static Map<String, dynamic> presetEfficientAndroid = {
+    "desiredStoppedUpdateInterval": 3600,
+    "fastestStoppedUpdateInterval": 1200,
+    "desiredMovingUpdateInterval": 1200,
+    "fastestMovingUpdateInterval": 360,
+    "desiredSyncInterval": 140,
+    "desiredAccuracy": 'medium',
+    "stopDuration": 140,
+    "stopDistance": 70,
+    "replay": 'stops',
+    "sync": 'all',
+    "useStoppedGeofence": false,
+    "stoppedGeofenceRadius": 0,
+    "useMovingGeofence": false,
+    "movingGeofenceRadius": 0,
+    "syncGeofences": true,
+    "syncGeofencesLimit": 10,
+    "foregroundServiceEnabled": false,
+    "beacons": false,
+    "startTrackingAfter": null,
+    "stopTrackingAfter": null,
+  };
 
   static Map<String, dynamic> presetResponsive =
       Platform.isIOS ? presetResponsiveIOS : presetResponsiveAndroid;
   static Map<String, dynamic> presetContinuous =
       Platform.isIOS ? presetContinuousIOS : presetContinuousAndroid;
-    static Map<String, dynamic> presetEfficient=
+  static Map<String, dynamic> presetEfficient =
       Platform.isIOS ? presetEfficientIOS : presetEfficientAndroid;
+}
+
+class RadarExistingCallbackException implements Exception {
+  @override
+  String toString() {
+    return 'Existing callback already exists for this event. Please call the corresponding `off` method first.';
+  }
 }


### PR DESCRIPTION
This PR adds location tracking/handling to foreground Flutter processes. Previously the only way to source location updates was in the context of a background isolate which provided no way to forward updates to a foreground instance (if there is one present).

This adds two methods:
`onLocationForeground`
`onClientLocationForeground`

Calling these methods will register callbacks for the lifetime of foreground process and are triggered whenever the SDK receives the respective event. Because the callbacks are bound to the lifetime foreground process these methods must be called every time the app is ran.