### PR TITLE
Ensure method channel doesn't get recreated due to background isolate

### DIFF
--- a/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
+++ b/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
@@ -79,7 +79,7 @@ public class RadarFlutterPlugin
     private static final String TAG = "RadarFlutterPlugin";
     private static final String CALLBACK_DISPATCHER_HANDLE_KEY = "callbackDispatcherHandle";
     private static MethodChannel sBackgroundChannel;
-    private MethodChannel channel;
+    private static MethodChannel channel;
 
     private static final Object lock = new Object();
 
@@ -89,10 +89,12 @@ public class RadarFlutterPlugin
     @Override
     public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
         mContext = binding.getApplicationContext();
-        channel = new MethodChannel(binding.getFlutterEngine().getDartExecutor(), "flutter_radar");
-        Radar.setReceiver(new RadarFlutterReceiver(channel));
-        Radar.setVerifiedReceiver(new RadarFlutterVerifiedReceiver(channel));
-        channel.setMethodCallHandler(this);
+        if (channel == null) {
+            channel = new MethodChannel(binding.getFlutterEngine().getDartExecutor(), "flutter_radar");
+            Radar.setReceiver(new RadarFlutterReceiver(channel));
+            Radar.setVerifiedReceiver(new RadarFlutterVerifiedReceiver(channel));
+            channel.setMethodCallHandler(this);
+        }
     }
 
     @Override


### PR DESCRIPTION
Event listeners don't work in background (when app is closed) if there is an isolate which has been created, since this creates a new flutter engine which creates a new instance of the flutter-radar plugin, and this recreates the method channel.

This change makes the method channel static and only creates it once