### PR TITLE
add getVerifiedLocationToken function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.12.0
+
+- Bump iOS version from 3.17.0 to 3.18.2
+- Bump Android version from 3.17.0 to 3.18.1
+- Add `getVerifiedLocationToken`
+
 # 3.11.0
 
 - Bump iOS version from 3.15.0 to 3.17.0

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,6 +28,8 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 31
+        versionCode 1
+        versionName '3.12.0'
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,7 +35,7 @@ android {
 }
 
 dependencies {
-    implementation 'io.radar:sdk:3.18.0'
+    implementation 'io.radar:sdk:3.18.1'
     implementation 'com.google.android.gms:play-services-location:21.0.1'
     implementation 'com.google.code.gson:gson:2.8.6'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,7 +35,7 @@ android {
 }
 
 dependencies {
-    implementation 'io.radar:sdk:3.17.0'
+    implementation 'io.radar:sdk:3.18.0'
     implementation 'com.google.android.gms:play-services-location:21.0.1'
     implementation 'com.google.code.gson:gson:2.8.6'
 }

--- a/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
+++ b/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
@@ -294,7 +294,7 @@ public class RadarFlutterPlugin implements FlutterPlugin, ActivityAware, Request
         String publishableKey = call.argument("publishableKey");
         SharedPreferences.Editor editor = mContext.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit();
         editor.putString("x_platform_sdk_type", "Flutter");
-        editor.putString("x_platform_sdk_version", "3.11.0");
+        editor.putString("x_platform_sdk_version", "3.12.0");
         editor.apply();
         Radar.initialize(mContext, publishableKey);
         Radar.setReceiver(new RadarFlutterReceiver(channel));

--- a/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
+++ b/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
@@ -1435,7 +1435,6 @@ public class RadarFlutterPlugin implements FlutterPlugin, ActivityAware, Request
                 }
                 
             } catch (Exception e) {
-                Log.e(TAG, "NULL PTR HERE");
                 Log.e(TAG, e.toString());
             }
         }

--- a/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
+++ b/android/src/main/java/io/radar/flutter/RadarFlutterPlugin.java
@@ -274,6 +274,9 @@ public class RadarFlutterPlugin implements FlutterPlugin, ActivityAware, Request
                     case "trackVerified":
                         trackVerified(call, result);
                         break;
+                    case "getVerifiedLocationToken":
+                        getVerifiedLocationToken(result);
+                        break;
                     case "validateAddress":
                         validateAddress(call, result);
                         break;
@@ -1182,6 +1185,31 @@ public class RadarFlutterPlugin implements FlutterPlugin, ActivityAware, Request
         Radar.trackVerified(beacons, callback);
     }
 
+    public static void getVerifiedLocationToken(Result result) {
+        Radar.RadarTrackVerifiedCallback callback = new Radar.RadarTrackVerifiedCallback() {
+            @Override
+            public void onComplete(final Radar.RadarStatus status, final RadarVerifiedLocationToken token) {
+                runOnMainThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            JSONObject obj = new JSONObject();
+                            obj.put("status", status.toString());
+                            obj.put("token", token.toJson());
+
+                            HashMap<String, Object> map = new Gson().fromJson(obj.toString(), HashMap.class);
+                            result.success(map);
+                        } catch (Exception e) {
+                            result.error(e.toString(), e.getMessage(), e.getMessage());
+                        }
+                    }
+                });
+            }
+        };
+
+        Radar.getVerifiedLocationToken(callback);
+    }
+
     private static void isUsingRemoteTrackingOptions(Result result) {
         Boolean isRemoteTracking = Radar.isUsingRemoteTrackingOptions();
         result.success(isRemoteTracking);
@@ -1407,6 +1435,7 @@ public class RadarFlutterPlugin implements FlutterPlugin, ActivityAware, Request
                 }
                 
             } catch (Exception e) {
+                Log.e(TAG, "NULL PTR HERE");
                 Log.e(TAG, e.toString());
             }
         }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -49,7 +49,7 @@ android {
     }
 
     dependencies {
-        implementation 'io.radar:sdk:3.17.0'
+        implementation 'io.radar:sdk:3.18.1'
         implementation "com.google.android.play:integrity:1.2.0"
     }
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     lintOptions {
         disable 'InvalidPackage'

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -433,7 +433,14 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
               },
               child: Text('trackVerified()'),
             ),
-            
+            ElevatedButton(
+              style: raisedButtonStyle,
+              onPressed: () async {
+                var resp = await Radar.getVerifiedLocationToken();
+                print("getVerifiedLocationToken: $resp");
+              },
+              child: Text('getVerifiedLocationToken()'),
+            ),
             ElevatedButton(
               style: raisedButtonStyle,
               onPressed: () async {

--- a/ios/Classes/RadarFlutterPlugin.m
+++ b/ios/Classes/RadarFlutterPlugin.m
@@ -125,7 +125,9 @@
     } else if ([@"setForegroundServiceOptions" isEqualToString:call.method]) {
         // do nothing
     } else if ([@"trackVerified" isEqualToString:call.method]) {
-        [self trackVerified:call withResult:result];    
+        [self trackVerified:call withResult:result];
+    } else if ([@"getVerifiedLocationToken" isEqualToString:call.method]) {
+        [self getVerifiedLocationToken:result];
     } else if ([@"isUsingRemoteTrackingOptions" isEqualToString:call.method]) {
         [self isUsingRemoteTrackingOptions:call withResult:result];    
     } else if ([@"validateAddress" isEqualToString:call.method]) {
@@ -986,6 +988,19 @@
     [Radar trackVerifiedWithBeacons:beacons completionHandler:completionHandler];
 }
 
+- (void)getVerifiedLocationToken:(FlutterResult)result {
+    RadarTrackVerifiedCompletionHandler completionHandler = ^(RadarStatus status, RadarVerifiedLocationToken* token) {
+        if (status == RadarStatusSuccess) {
+            NSMutableDictionary *dict = [NSMutableDictionary new];
+            [dict setObject:[Radar stringForStatus:status] forKey:@"status"];
+            [dict setObject:[token dictionaryValue] forKey:@"token"];
+            result(dict);
+        }
+    };
+
+    [Radar getVerifiedLocationToken:completionHandler];
+}
+
 - (void)validateAddress:(FlutterMethodCall *)call withResult:(FlutterResult)result {
   RadarValidateAddressCompletionHandler completionHandler = ^(RadarStatus status, RadarAddress * _Nullable address, RadarAddressVerificationStatus verificationStatus) {
       NSMutableDictionary *dict = [NSMutableDictionary new];
@@ -1044,8 +1059,8 @@
     }
 }
 
-- (void)didUpdateToken:(NSString *)token {
-    NSDictionary *dict = @{@"token": token};    
+- (void)didUpdateToken:(RadarVerifiedLocationToken *)token {
+    NSDictionary *dict = @{@"token": [token dictionaryValue]};    
     NSArray* args = @[@0, dict];
     if (self.channel != nil) {
         [self.channel invokeMethod:@"token" arguments:args];

--- a/ios/Classes/RadarFlutterPlugin.m
+++ b/ios/Classes/RadarFlutterPlugin.m
@@ -142,7 +142,7 @@
 
     NSString *publishableKey = argsDict[@"publishableKey"];
     [[NSUserDefaults standardUserDefaults] setObject:@"Flutter" forKey:@"radar-xPlatformSDKType"];
-    [[NSUserDefaults standardUserDefaults] setObject:@"3.11.0" forKey:@"radar-xPlatformSDKVersion"];
+    [[NSUserDefaults standardUserDefaults] setObject:@"3.12.0" forKey:@"radar-xPlatformSDKVersion"];
     [Radar initializeWithPublishableKey:publishableKey];
     result(nil);
 }

--- a/ios/flutter_radar.podspec
+++ b/ios/flutter_radar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'flutter_radar'
-  s.version          = '3.11.0'
+  s.version          = '3.12.0'
   s.summary          = 'Flutter package for Radar, the leading geofencing and location tracking platform'
   s.description      = 'Flutter package for Radar, the leading geofencing and location tracking platform'
   s.homepage         = 'http://example.com'

--- a/ios/flutter_radar.podspec
+++ b/ios/flutter_radar.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'RadarSDK', '3.17.0'
+  s.dependency 'RadarSDK', '3.18.0'
   s.platform = :ios, '10.0'
   s.static_framework = true
 

--- a/ios/flutter_radar.podspec
+++ b/ios/flutter_radar.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'RadarSDK', '3.18.0'
+  s.dependency 'RadarSDK', '3.18.2'
   s.platform = :ios, '10.0'
   s.static_framework = true
 

--- a/lib/flutter_radar.dart
+++ b/lib/flutter_radar.dart
@@ -505,6 +505,14 @@ class Radar {
     }
   }
 
+  static Future<Map?> getVerifiedLocationToken() async {
+    try {
+      return await _channel.invokeMethod('getVerifiedLocationToken');
+    } on PlatformException catch (e) {
+      print(e);
+    }
+  }
+
   static Future<bool?> isUsingRemoteTrackingOptions() async {
     return await _channel.invokeMethod('isUsingRemoteTrackingOptions');
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_radar
 description: Flutter package for Radar, the leading geofencing and location tracking platform
-version: 3.11.0
+version: 3.12.0
 homepage: https://github.com/radarlabs/flutter-radar
 
 environment:


### PR DESCRIPTION
add `Radar.getVerifiedLocationToken()` function.

tested with example app, with google play integrity API and AppAttest API on iOS.

turn on `Fraud > Enable Android Play Integrity API + Enable iOS App Attest`, then run `getVerifiedLocationToken()` from the app.

I routed the apis to a local server to check the requests (by using SharedPreference / standardUserDefaults to set the api hosts). Verified the tokens are generated + passed to server.