### PR TITLE
FENCE-2390: Update example app

### DIFF
--- a/example/lib/api_section.dart
+++ b/example/lib/api_section.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+class ApiAction {
+  final String label;
+  final Future<Object?> Function() run;
+
+  const ApiAction(this.label, this.run);
+}
+
+class ApiSection {
+  final String title;
+  final IconData icon;
+  final List<ApiAction> actions;
+
+  const ApiSection({
+    required this.title,
+    required this.icon,
+    required this.actions,
+  });
+}
+
+class ApiSectionCard extends StatelessWidget {
+  final ApiSection section;
+  final ValueChanged<ApiAction> onRun;
+  final bool initiallyExpanded;
+
+  const ApiSectionCard({
+    super.key,
+    required this.section,
+    required this.onRun,
+    this.initiallyExpanded = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      child: ExpansionTile(
+        initiallyExpanded: initiallyExpanded,
+        leading: Icon(section.icon, color: theme.colorScheme.primary),
+        title: Text(section.title, style: theme.textTheme.titleSmall),
+        subtitle: Text(
+          '${section.actions.length} ${section.actions.length == 1 ? 'call' : 'calls'}',
+          style: theme.textTheme.bodySmall,
+        ),
+        childrenPadding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+        expandedCrossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              for (final action in section.actions)
+                FilledButton.tonal(
+                  onPressed: () => onRun(action),
+                  style: FilledButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(horizontal: 14),
+                    textStyle: const TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  child: Text(action.label),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/console.dart
+++ b/example/lib/console.dart
@@ -1,0 +1,334 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+enum ConsoleStatus { success, error }
+
+class ConsoleEntry {
+  final String label;
+  final ConsoleStatus status;
+  final String body;
+  final DateTime timestamp;
+
+  ConsoleEntry({
+    required this.label,
+    required this.status,
+    required this.body,
+  }) : timestamp = DateTime.now();
+
+  String get formattedTime {
+    final h = timestamp.hour.toString().padLeft(2, '0');
+    final m = timestamp.minute.toString().padLeft(2, '0');
+    final s = timestamp.second.toString().padLeft(2, '0');
+    return '$h:$m:$s';
+  }
+}
+
+/// Shared by the UI and the static, top-level callbacks that Radar invokes,
+/// which cannot reach widget state.
+final ConsoleController console = ConsoleController();
+
+class ConsoleController extends ChangeNotifier {
+  static const int _maxEntries = 200;
+
+  final List<ConsoleEntry> _entries = [];
+
+  List<ConsoleEntry> get entries => List.unmodifiable(_entries);
+
+  bool get isEmpty => _entries.isEmpty;
+
+  void log(String label, Object? result, {ConsoleStatus? status}) {
+    _add(ConsoleEntry(
+      label: label,
+      status: status ?? (looksLikeError(result) ? ConsoleStatus.error : ConsoleStatus.success),
+      body: prettyValue(result),
+    ));
+  }
+
+  /// Listener events fire continuously once tracking starts, so they go to the
+  /// terminal rather than the in-app console, which is reserved for the
+  /// response of whichever button was pressed.
+  void logEvent(String label, Object? payload) {
+    debugPrint('[$label] ${prettyValue(payload)}');
+  }
+
+  void logError(String label, Object error) {
+    _add(ConsoleEntry(
+      label: label,
+      status: ConsoleStatus.error,
+      body: error.toString(),
+    ));
+  }
+
+  void clear() {
+    _entries.clear();
+    notifyListeners();
+  }
+
+  String asText() => _entries
+      .map((e) => '[${e.formattedTime}] ${e.label}\n${e.body}')
+      .join('\n\n');
+
+  void _add(ConsoleEntry entry) {
+    _entries.insert(0, entry);
+    if (_entries.length > _maxEntries) {
+      _entries.removeLast();
+    }
+    notifyListeners();
+  }
+}
+
+/// The plugin reports failures as a `status` string or an `error` key rather
+/// than by throwing, so success can't be inferred from the call completing.
+bool looksLikeError(Object? result) {
+  if (result is! Map) return false;
+  if (result['error'] != null) return true;
+  final status = result['status'];
+  return status is String && status != 'SUCCESS';
+}
+
+String prettyValue(Object? value) {
+  if (value == null) return 'null';
+  if (value is String) return value.isEmpty ? '""' : value;
+  try {
+    return const JsonEncoder.withIndent('  ').convert(_normalize(value));
+  } catch (_) {
+    return value.toString();
+  }
+}
+
+/// Platform channels hand back `Map<Object?, Object?>`, which `jsonEncode`
+/// rejects; keys have to be coerced to strings first.
+Object? _normalize(Object? value) {
+  if (value == null || value is num || value is bool || value is String) {
+    return value;
+  }
+  if (value is Map) {
+    return value.map((k, v) => MapEntry('$k', _normalize(v)));
+  }
+  if (value is Iterable) {
+    return value.map(_normalize).toList();
+  }
+  return value.toString();
+}
+
+class ConsolePanel extends StatefulWidget {
+  const ConsolePanel({super.key});
+
+  @override
+  State<ConsolePanel> createState() => _ConsolePanelState();
+}
+
+class _ConsolePanelState extends State<ConsolePanel> {
+  bool _expanded = true;
+
+  @override
+  void initState() {
+    super.initState();
+    console.addListener(_onConsoleChanged);
+  }
+
+  @override
+  void dispose() {
+    console.removeListener(_onConsoleChanged);
+    super.dispose();
+  }
+
+  void _onConsoleChanged() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final entries = console.entries;
+    final maxHeight = MediaQuery.of(context).size.height * 0.42;
+
+    return Material(
+      elevation: 12,
+      color: theme.colorScheme.surfaceContainerHighest,
+      child: SafeArea(
+        top: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _header(theme, entries.length),
+            AnimatedSize(
+              duration: const Duration(milliseconds: 180),
+              curve: Curves.easeOut,
+              child: SizedBox(
+                height: _expanded ? maxHeight : 0,
+                width: double.infinity,
+                child: entries.isEmpty
+                    ? _emptyState(theme)
+                    : ListView.separated(
+                        padding: const EdgeInsets.fromLTRB(12, 4, 12, 12),
+                        itemCount: entries.length,
+                        separatorBuilder: (_, __) => const SizedBox(height: 6),
+                        itemBuilder: (context, i) => _EntryTile(entry: entries[i]),
+                      ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _header(ThemeData theme, int count) {
+    return InkWell(
+      onTap: () => setState(() => _expanded = !_expanded),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 10, 8, 10),
+        child: Row(
+          children: [
+            Icon(
+              _expanded ? Icons.keyboard_arrow_down : Icons.keyboard_arrow_up,
+              size: 20,
+            ),
+            const SizedBox(width: 8),
+            Text('Console', style: theme.textTheme.titleSmall),
+            const SizedBox(width: 8),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.primaryContainer,
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Text(
+                '$count',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.onPrimaryContainer,
+                ),
+              ),
+            ),
+            const Spacer(),
+            IconButton(
+              tooltip: 'Copy all',
+              icon: const Icon(Icons.copy_all, size: 20),
+              onPressed: count == 0
+                  ? null
+                  : () {
+                      Clipboard.setData(ClipboardData(text: console.asText()));
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('Console copied'),
+                          duration: Duration(seconds: 1),
+                        ),
+                      );
+                    },
+            ),
+            IconButton(
+              tooltip: 'Clear',
+              icon: const Icon(Icons.delete_outline, size: 20),
+              onPressed: count == 0 ? null : console.clear,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _emptyState(ThemeData theme) {
+    return Center(
+      child: Text(
+        'Run an API call to see results here',
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+}
+
+class _EntryTile extends StatefulWidget {
+  final ConsoleEntry entry;
+
+  const _EntryTile({required this.entry});
+
+  @override
+  State<_EntryTile> createState() => _EntryTileState();
+}
+
+class _EntryTileState extends State<_EntryTile> {
+  bool _expanded = false;
+
+  static const int _collapsedLineLimit = 3;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final entry = widget.entry;
+    final lines = entry.body.split('\n');
+    final isTruncatable = lines.length > _collapsedLineLimit;
+    final body = _expanded || !isTruncatable
+        ? entry.body
+        : '${lines.take(_collapsedLineLimit).join('\n')}\n…';
+
+    return Card(
+      margin: EdgeInsets.zero,
+      color: theme.colorScheme.surface,
+      child: InkWell(
+        onTap: isTruncatable ? () => setState(() => _expanded = !_expanded) : null,
+        onLongPress: () {
+          Clipboard.setData(ClipboardData(text: '${entry.label}\n${entry.body}'));
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Entry copied'),
+              duration: Duration(seconds: 1),
+            ),
+          );
+        },
+        child: Padding(
+          padding: const EdgeInsets.all(10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  _statusDot(entry.status),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      entry.label,
+                      style: theme.textTheme.labelLarge,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  Text(
+                    entry.formattedTime,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 6),
+              SelectableText(
+                body,
+                style: const TextStyle(
+                  fontFamily: 'monospace',
+                  fontSize: 11,
+                  height: 1.35,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _statusDot(ConsoleStatus status) {
+    final color = switch (status) {
+      ConsoleStatus.success => Colors.green,
+      ConsoleStatus.error => Colors.red,
+    };
+    return Container(
+      width: 8,
+      height: 8,
+      decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,30 +1,117 @@
 import 'package:flutter/material.dart';
-import 'dart:async';
 import 'package:flutter_radar/flutter_radar.dart';
 import 'package:permission_handler/permission_handler.dart';
 
-void main() => runApp(MyApp());
+import 'api_section.dart';
+import 'console.dart';
 
+const String publishableKey =
+    'prj_test_pk_7b46891aa0a8278b5acc6bbc9f227aa5c3319483';
 
+const Map<String, double> _manhattan = {
+  'latitude': 40.783826,
+  'longitude': -73.975363,
+};
 
-class MyApp extends StatefulWidget {
+const Map<String, double> _brooklyn = {
+  'latitude': 40.703900,
+  'longitude': -73.986700,
+};
+
+void main() => runApp(const MyApp());
+
+// Radar can invoke these from a background isolate, so they must be top-level
+// entry points rather than methods on widget state.
+@pragma('vm:entry-point')
+void _onLocation(Map res) => console.logEvent('onLocation', res);
+
+@pragma('vm:entry-point')
+void _onClientLocation(Map res) => console.logEvent('onClientLocation', res);
+
+@pragma('vm:entry-point')
+void _onError(Map res) => console.logEvent('onError', res);
+
+@pragma('vm:entry-point')
+void _onLog(Map res) => console.logEvent('onLog', res);
+
+@pragma('vm:entry-point')
+void _onEvents(Map res) => console.logEvent('onEvents', res);
+
+@pragma('vm:entry-point')
+void _onToken(Map res) => console.logEvent('onToken', res);
+
+@pragma('vm:entry-point')
+void _onIpChanged() => console.logEvent('onIpChanged', 'IP address changed');
+
+@pragma('vm:entry-point')
+void _onSharingChanged(bool sharing) =>
+    console.logEvent('onSharingChanged', {'sharing': sharing});
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
   @override
-  _MyAppState createState() => _MyAppState();
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'flutter_radar example',
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        useMaterial3: true,
+        colorSchemeSeed: const Color(0xFF3B5BFF),
+      ),
+      home: const HomePage(),
+    );
+  }
 }
 
-class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
-  final ButtonStyle raisedButtonStyle = ElevatedButton.styleFrom(
-    minimumSize: Size(88, 36),
-    padding: EdgeInsets.symmetric(horizontal: 16),
-    shape: const RoundedRectangleBorder(
-      borderRadius: BorderRadius.all(Radius.circular(2)),
-    ),
-  );
+class _ListenerDef {
+  final String name;
+  final void Function() enable;
+  final void Function() disable;
+
+  const _ListenerDef(this.name, this.enable, this.disable);
+}
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
+  String _permissionStatus = 'UNKNOWN';
+  String? _tripId;
+  List<String> _legIds = [];
+
+  final Set<String> _enabledListeners = {};
+
+  late final List<_ListenerDef> _listenerDefs = [
+    _ListenerDef('onLocation', () => Radar.onLocation(_onLocation),
+        () => Radar.offLocation()),
+    _ListenerDef('onClientLocation',
+        () => Radar.onClientLocation(_onClientLocation), () => Radar.offClientLocation()),
+    _ListenerDef('onError', () => Radar.onError(_onError), () => Radar.offError()),
+    _ListenerDef('onLog', () => Radar.onLog(_onLog), () => Radar.offLog()),
+    _ListenerDef('onEvents', () => Radar.onEvents(_onEvents), () => Radar.offEvents()),
+    _ListenerDef('onToken', () => Radar.onToken(_onToken), () => Radar.offToken()),
+    _ListenerDef('onIpChanged', () => Radar.onIpChanged(_onIpChanged),
+        () => Radar.offIpChanged()),
+    _ListenerDef('onSharingChanged',
+        () => Radar.onSharingChanged(_onSharingChanged), () => Radar.offSharingChanged()),
+  ];
 
   @override
   void initState() {
     super.initState();
-    initRadar();
+    WidgetsBinding.instance.addObserver(this);
+    _initRadar();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
   }
 
   @override
@@ -36,596 +123,584 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
     }
   }
 
-  // Add this to iOS callback for termination; Android calls this automatically
-  // Radar.logTermination();
-  @pragma('vm:entry-point')
-  static void onLocation(Map res) {
-    print('📍📍 onLocation: $res');
-  }
-
-  @pragma('vm:entry-point')
-  static void onClientLocation(Map res) {
-    print('📍📍 onClientLocation: $res');
-  }
-
-  @pragma('vm:entry-point')
-  static void onError(Map res) {
-    print('📍📍 onError: $res');
-  }
-
-  @pragma('vm:entry-point')
-  static void onLog(Map res) {
-    print('📍📍 onLog: $res');
-  }
-
-  @pragma('vm:entry-point')
-  static void onEvents(Map res) {
-    print('📍📍 onEvents: $res');
-  }
-
-  @pragma('vm:entry-point')
-  static void onToken(Map res) {
-    print('📍📍 onToken: $res');
-  }
-
-  Future<void> initRadar() async {
-    Radar.initialize(
-      'prj_test_pk_0000000000000000000000000000000000000000',
+  Future<void> _initRadar() async {
+    await Radar.initialize(
+      publishableKey,
       options: RadarInitializeOptions(
-      fraud: true,
-      trackVerifiedAutoFailover: true,
-      networkTimeout: Duration(seconds: 20),
-      ipChangeDebounceInterval: Duration(seconds: 5),
-    ),
-  );
-    Radar.setUserId('flutter');
-    Radar.setDescription('Flutter');
-    Radar.setMetadata({'foo': 'bar', 'bax': true, 'qux': 1});
-    Radar.setLogLevel('info');
-    Radar.setAnonymousTrackingEnabled(false);
+        fraud: true,
+        trackVerifiedAutoFailover: true,
+        networkTimeout: const Duration(seconds: 20),
+        ipChangeDebounceInterval: const Duration(seconds: 5),
+      ),
+    );
+    await Radar.setUserId('flutter');
+    await Radar.setDescription('Flutter');
+    await Radar.setMetadata({'foo': 'bar', 'bax': true, 'qux': 1});
+    await Radar.setLogLevel('info');
+    await Radar.setAnonymousTrackingEnabled(false);
 
-    Radar.onLocation(onLocation);
-    Radar.onClientLocation(onClientLocation);
-    Radar.onError(onError);
-    Radar.onEvents(onEvents);
-    Radar.onLog(onLog);
-    Radar.onToken(onToken);
-
-    await Radar.requestPermissions(false);
-
-    await Radar.requestPermissions(true);
-    var permissionStatus = await Radar.getPermissionsStatus();
-    if (permissionStatus != "DENIED") {
-      await Radar.startTrackingCustom({
-        ... Radar.presetResponsive,
-        "showBlueBar": true,
-      });
-      //Radar.startTracking('continuous');
-
-      var c = await Radar.getTrackingOptions();
-      print("Tracking options $c");
+    for (final def in _listenerDefs) {
+      _setListener(def, true);
     }
+
+    await _refreshPermissions();
+    console.log('initialize', 'Radar initialized');
+  }
+
+  Future<void> _refreshPermissions() async {
+    final status = await Radar.getPermissionsStatus();
+    if (mounted) {
+      setState(() => _permissionStatus = status ?? 'UNKNOWN');
+    }
+  }
+
+  void _setListener(_ListenerDef def, bool enabled) {
+    try {
+      if (enabled) {
+        def.enable();
+      } else {
+        def.disable();
+      }
+      setState(() {
+        if (enabled) {
+          _enabledListeners.add(def.name);
+        } else {
+          _enabledListeners.remove(def.name);
+        }
+      });
+    } catch (e) {
+      console.logError(def.name, e);
+    }
+  }
+
+  Future<void> _run(ApiAction action) async {
+    try {
+      final result = await action.run();
+      console.log(action.label, result);
+    } catch (e) {
+      console.logError(action.label, e);
+    }
+  }
+
+  /// Leg operations need IDs minted by the server, so the multi-destination
+  /// trip response is stashed for the buttons that follow it.
+  void _captureTrip(Object? response) {
+    if (response is! Map) return;
+    final trip = response['trip'];
+    if (trip is! Map) return;
+    final legs = trip['legs'];
+    setState(() {
+      _tripId = trip['_id'] as String?;
+      _legIds = legs is List
+          ? legs
+              .whereType<Map>()
+              .map((leg) => leg['_id'])
+              .whereType<String>()
+              .toList()
+          : <String>[];
+    });
+  }
+
+  Future<String?> _prompt(String title, {String initial = ''}) async {
+    final controller = TextEditingController(text: initial);
+    return showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(title),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: const InputDecoration(border: OutlineInputBorder()),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, controller.text),
+            child: const Text('Run'),
+          ),
+        ],
+      ),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
+    final sections = _sections();
 
-    return MaterialApp(
-        home: Scaffold(
+    return Scaffold(
       appBar: AppBar(
-        title: const Text('flutter_radar_example'),
+        title: const Text('flutter_radar'),
+        actions: [
+          IconButton(
+            tooltip: 'Refresh permissions',
+            icon: const Icon(Icons.refresh),
+            onPressed: _refreshPermissions,
+          ),
+        ],
       ),
-      body: SingleChildScrollView(
-        scrollDirection: Axis.vertical,
-        child: Container(
-          child: Column(children: [
-            Permissions(),
-            TrackOnce(),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () async {
-                var status = await Radar.requestPermissions(false);
-                print(status);
-                if (status == 'GRANTED_FOREGROUND') {
-                  status = await Radar.requestPermissions(true);
-                  print(status);
-                }
-              },
-              child: Text('requestPermissions()'),
+      body: Column(
+        children: [
+          _statusBar(context),
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.only(top: 8, bottom: 16),
+              children: [
+                for (int i = 0; i < sections.length; i++)
+                  ApiSectionCard(
+                    section: sections[i],
+                    onRun: _run,
+                    initiallyExpanded: i == 0,
+                  ),
+                _listenersCard(context),
+              ],
             ),
-            ElevatedButton(
-                style: raisedButtonStyle,
-                onPressed: () async {
-                  PermissionStatus status =
-                      await Permission.activityRecognition.request();
-                  if (status.isGranted) {
-                    print('Permission granted');
-                  } else {
-                    print('Permission denied');
-                  }
-                },
-                child: Text('request activity permissions'),
+          ),
+          const ConsolePanel(),
+        ],
+      ),
+    );
+  }
+
+  Widget _statusBar(BuildContext context) {
+    final theme = Theme.of(context);
+    final chips = <String>[
+      'permissions: $_permissionStatus',
+      if (_tripId != null) 'trip: ${_tripId!.substring(0, 8)}…',
+      if (_legIds.isNotEmpty) 'legs: ${_legIds.length}',
+    ];
+
+    return Container(
+      width: double.infinity,
+      color: theme.colorScheme.surfaceContainerHighest,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: Wrap(
+        spacing: 6,
+        runSpacing: 6,
+        children: [
+          for (final chip in chips)
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surface,
+                borderRadius: BorderRadius.circular(12),
               ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () async {
-                var resp = await Radar.showInAppMessage({
-                    "type": "banner",
-                    "title": {
-                        "text": "This is the title",
-                        "color": "#000000"
-                    },
-                    "body": {
-                        "text": "This is a demo message",
-                        "color": "#666666"
-                    },
-                    "button": {
-                        "text": "Send it",
-                        "color": "#FFFFFF",
-                        "backgroundColor": "#EB0083"
-                    }
-                });
-                print("showInAppMessage: $resp");
-              },
-              child: Text('showInAppMessage'),
+              child: Text(chip, style: theme.textTheme.labelSmall),
             ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () async {
-                Radar.setForegroundServiceOptions({
-                  'title': 'Tracking',
-                  'text': 'Trip tracking started',
-                  'iconString': "ic_notification",
-                  'iconColor': "#FF6B8D",
-                  'importance': 2,
-                  'updatesOnly': false,
-                  'activity': 'io.radar.example.MainActivity'
-                });
-                var resp = await Radar.startTrip(
-                    tripOptions: {
-                    "externalId": '299',
-                    "destinationGeofenceTag": 'store',
-                    "destinationGeofenceExternalId": '123',
-                    "mode": 'car',
-                    "scheduledArrivalAt": "2020-08-20T10:30:55.837Z",
-                    "metadata": {"test": 123}
-                    },
-                    trackingOptions: {
-                      "desiredStoppedUpdateInterval": 30,
-                      "fastestStoppedUpdateInterval": 30,
-                      "desiredMovingUpdateInterval": 30,
-                      "fastestMovingUpdateInterval": 30,
-                      "desiredSyncInterval": 20,
-                      "desiredAccuracy": "high",
-                      "stopDuration": 0,
-                      "stopDistance": 0,
-                      "replay": "none",
-                      "sync": "all",
-                      "showBlueBar": true,
-                      "useStoppedGeofence": false,
-                      "stoppedGeofenceRadius": 0,
-                      "useMovingGeofence": false,
-                      "movingGeofenceRadius": 0,
-                      "syncGeofences": false,
-                      "syncGeofencesLimit": 0,
-                      "beacons": false,
-                      "foregroundServiceEnabled": true
-                    }
-                );
-                print("startTrip: $resp");
-              },
-              child: Text('startTrip'),
+        ],
+      ),
+    );
+  }
+
+  Widget _listenersCard(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      child: ExpansionTile(
+        leading: Icon(Icons.podcasts, color: theme.colorScheme.primary),
+        title: Text('Listeners', style: theme.textTheme.titleSmall),
+        subtitle: Text(
+          '${_enabledListeners.length} of ${_listenerDefs.length} active',
+          style: theme.textTheme.bodySmall,
+        ),
+        children: [
+          for (final def in _listenerDefs)
+            SwitchListTile(
+              dense: true,
+              title: Text(def.name, style: theme.textTheme.bodyMedium),
+              value: _enabledListeners.contains(def.name),
+              onChanged: (value) => _setListener(def, value),
             ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () async {
-                var resp = await Radar.completeTrip();
-                print("completeTrip: $resp");
-              },
-              child: Text('completeTrip'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () async {
-                var resp = await Radar.cancelTrip();
-                print("cancelTrip: $resp");
-              },
-              child: Text('cancelTrip'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () async {
-                var resp = await Radar.getTrackingOptions();
-                print("getTrackingOptions: $resp");
-              },
-              child: Text('getTrackingOptions'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () async {
-                var resp = await Radar.updateTrip(
-                  status:'arrived',
+        ],
+      ),
+    );
+  }
+
+  List<ApiSection> _sections() => [
+        ApiSection(
+          title: 'Setup & Status',
+          icon: Icons.tune,
+          actions: [
+            ApiAction('isInitialized()', () => Radar.isInitialized()),
+            ApiAction('sdkVersion()', () => Radar.sdkVersion()),
+            ApiAction('getPermissionsStatus()', () => Radar.getPermissionsStatus()),
+            ApiAction('requestPermissions(foreground)', () async {
+              final status = await Radar.requestPermissions(false);
+              await _refreshPermissions();
+              return status;
+            }),
+            ApiAction('requestPermissions(background)', () async {
+              final status = await Radar.requestPermissions(true);
+              await _refreshPermissions();
+              return status;
+            }),
+            ApiAction('activityRecognition permission', () async {
+              final status = await Permission.activityRecognition.request();
+              return status.toString();
+            }),
+            ApiAction("setLogLevel('info')", () async {
+              await Radar.setLogLevel('info');
+              return 'info';
+            }),
+            ApiAction("setLogLevel('debug')", () async {
+              await Radar.setLogLevel('debug');
+              return 'debug';
+            }),
+          ],
+        ),
+        ApiSection(
+          title: 'User & Metadata',
+          icon: Icons.person_outline,
+          actions: [
+            ApiAction('setUserId()', () async {
+              final value = await _prompt('setUserId', initial: 'flutter');
+              if (value == null) return 'cancelled';
+              await Radar.setUserId(value);
+              return value;
+            }),
+            ApiAction('getUserId()', () => Radar.getUserId()),
+            ApiAction('setDescription()', () async {
+              final value = await _prompt('setDescription', initial: 'Flutter');
+              if (value == null) return 'cancelled';
+              await Radar.setDescription(value);
+              return value;
+            }),
+            ApiAction('getDescription()', () => Radar.getDescription()),
+            ApiAction('setMetadata()', () async {
+              await Radar.setMetadata({'foo': 'bar', 'bax': true, 'qux': 1});
+              return {'foo': 'bar', 'bax': true, 'qux': 1};
+            }),
+            ApiAction('getMetadata()', () => Radar.getMetadata()),
+            ApiAction("setUserLanguage('es')", () async {
+              await Radar.setUserLanguage('es');
+              return 'es';
+            }),
+            ApiAction('getUserLanguage()', () => Radar.getUserLanguage()),
+            ApiAction("setProduct('flutter-qa')", () async {
+              await Radar.setProduct('flutter-qa');
+              return 'flutter-qa';
+            }),
+            ApiAction('getProduct()', () => Radar.getProduct()),
+            ApiAction('setTags([qa, flutter])', () async {
+              await Radar.setTags(['qa', 'flutter']);
+              return ['qa', 'flutter'];
+            }),
+            ApiAction('getTags()', () => Radar.getTags()),
+            ApiAction("addTags(['beta'])", () async {
+              await Radar.addTags(['beta']);
+              return Radar.getTags();
+            }),
+            ApiAction("removeTags(['beta'])", () async {
+              await Radar.removeTags(['beta']);
+              return Radar.getTags();
+            }),
+            ApiAction('setAnonymousTracking(true)', () async {
+              await Radar.setAnonymousTrackingEnabled(true);
+              return 'enabled';
+            }),
+            ApiAction('setAnonymousTracking(false)', () async {
+              await Radar.setAnonymousTrackingEnabled(false);
+              return 'disabled';
+            }),
+          ],
+        ),
+        ApiSection(
+          title: 'Tracking',
+          icon: Icons.my_location,
+          actions: [
+            ApiAction('trackOnce()', () => Radar.trackOnce()),
+            ApiAction('trackOnce(location)',
+                () => Radar.trackOnce(location: Map<String, dynamic>.from(_manhattan))),
+            ApiAction("getLocation('high')", () => Radar.getLocation('high')),
+            ApiAction("startTracking('responsive')", () async {
+              await Radar.startTracking('responsive');
+              return 'responsive';
+            }),
+            ApiAction("startTracking('continuous')", () async {
+              await Radar.startTracking('continuous');
+              return 'continuous';
+            }),
+            ApiAction("startTracking('efficient')", () async {
+              await Radar.startTracking('efficient');
+              return 'efficient';
+            }),
+            ApiAction('startTrackingCustom()', () async {
+              await Radar.startTrackingCustom({
+                ...Radar.presetResponsive,
+                'showBlueBar': true,
+                'foregroundServiceEnabled': true,
+              });
+              return Radar.getTrackingOptions();
+            }),
+            ApiAction('stopTracking()', () async {
+              await Radar.stopTracking();
+              return 'stopped';
+            }),
+            ApiAction('isTracking()', () => Radar.isTracking()),
+            ApiAction('getTrackingOptions()', () => Radar.getTrackingOptions()),
+            ApiAction('isUsingRemoteTrackingOptions()',
+                () => Radar.isUsingRemoteTrackingOptions()),
+            ApiAction('mockTracking()', () => Radar.mockTracking(
+                  origin: _manhattan,
+                  destination: _brooklyn,
+                  mode: 'car',
+                  steps: 3,
+                  interval: 3,
+                )),
+            ApiAction('setForegroundServiceOptions()', () async {
+              await Radar.setForegroundServiceOptions({
+                'title': 'Tracking',
+                'text': 'Flutter example is tracking',
+                'iconString': 'ic_notification',
+                'iconColor': '#FF6B8D',
+                'importance': 2,
+                'updatesOnly': false,
+                'activity': 'io.radar.example.MainActivity',
+              });
+              return 'ok';
+            }),
+          ],
+        ),
+        ApiSection(
+          title: 'Verified & Fraud',
+          icon: Icons.verified_user_outlined,
+          actions: [
+            ApiAction('trackVerified()', () => Radar.trackVerified()),
+            ApiAction('trackVerified(beacons)',
+                () => Radar.trackVerified(beacons: true, reason: 'qa')),
+            ApiAction('startTrackingVerified()', () async {
+              await Radar.startTrackingVerified(30, false);
+              return 'started';
+            }),
+            ApiAction('stopTrackingVerified()', () async {
+              await Radar.stopTrackingVerified();
+              return 'stopped';
+            }),
+            ApiAction('isTrackingVerified()', () => Radar.isTrackingVerified()),
+            ApiAction('getVerifiedLocationToken()',
+                () => Radar.getVerifiedLocationToken()),
+            ApiAction('clearVerifiedLocationToken()', () async {
+              await Radar.clearVerifiedLocationToken();
+              return 'cleared';
+            }),
+            ApiAction('revealRisk()', () => Radar.revealRisk()),
+            ApiAction('isSharing()', () => Radar.isSharing()),
+            ApiAction('clearSharing()', () async {
+              await Radar.clearSharing();
+              return 'cleared';
+            }),
+            ApiAction('setExpectedJurisdiction(US/NY)', () async {
+              await Radar.setExpectedJurisdiction(
+                  countryCode: 'US', stateCode: 'NY');
+              return 'US / NY';
+            }),
+            ApiAction('setExpectedJurisdiction(clear)', () async {
+              await Radar.setExpectedJurisdiction();
+              return 'cleared';
+            }),
+          ],
+        ),
+        ApiSection(
+          title: 'Trips',
+          icon: Icons.route_outlined,
+          actions: [
+            ApiAction('startTrip (single destination)', () async {
+              final response = await Radar.startTrip(tripOptions: {
+                'externalId': 'flutter-${DateTime.now().millisecondsSinceEpoch}',
+                'destinationGeofenceTag': 'store',
+                'destinationGeofenceExternalId': '123',
+                'mode': 'car',
+                'metadata': {'test': 123},
+              });
+              _captureTrip(response);
+              return response;
+            }),
+            ApiAction('startTrip (multi-destination)', () async {
+              final response = await Radar.startTrip(tripOptions: {
+                'externalId': 'flutter-multi-${DateTime.now().millisecondsSinceEpoch}',
+                'mode': 'car',
+                'legs': [
+                  {
+                    'destinationGeofenceTag': 'store',
+                    'destinationGeofenceExternalId': '123',
+                  },
+                  {'address': '841 Broadway, New York, NY'},
+                  {
+                    // GeoJSON order, and both SDKs index it positionally: a
+                    // {latitude, longitude} map passes the length check and
+                    // then crashes on element access.
+                    'coordinates': [
+                      _brooklyn['longitude'],
+                      _brooklyn['latitude'],
+                    ],
+                    'arrivalRadius': 100,
+                  },
+                ],
+              });
+              _captureTrip(response);
+              return response;
+            }),
+            ApiAction('getTrip()', () async {
+              final response = await Radar.getTrip();
+              _captureTrip({'trip': response});
+              return response;
+            }),
+            ApiAction('getTripOptions()', () => Radar.getTripOptions()),
+            ApiAction("updateTrip('arrived')", () => Radar.updateTrip(
+                  status: 'arrived',
                   options: {
-                    "externalId": '299',
-                    "metadata": {
-                      "parkingSpot": '5'
-                    }
-                  }
-                );
-                print("updateTrip: $resp");
-              },
-              child: Text('updateTrip'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () async {
-                var resp = await Radar.logConversion(
-                    name: "in_app_purchase",
-                    revenue: 0.2,
-                    metadata: {"price": "150USD"});
-                print("logConversion: $resp");
-              },
-              child: Text('logConversion'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () async {
-                await Radar.setNotificationOptions({
-                  'iconString': 'icon'
-                });
-              },
-              child: Text('setNotificationOptions'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () async {
-                var resp = await Radar.searchPlaces(
-                  near: {
-                    'latitude': 40.783826,
-                    'longitude': -73.975363,
+                    'externalId': 'flutter-trip',
+                    'metadata': {'parkingSpot': '5'},
                   },
-                  radius: 1000,
-                  chains: ["starbucks"],
-                  chainMetadata: {
-                    "customFlag": "true"
-                  },
-                  limit: 10,
-                );
-                print("searchPlaces: $resp");
-              },
-              child: Text('searchPlaces()'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () async {
-                var resp = await Radar.searchGeofences(
-                  near: {
-                    'latitude': 40.783826,
-                    'longitude': -73.975363,
-                  },
+                )),
+            ApiAction('updateTripLeg (first leg)', () async {
+              if (_legIds.isEmpty) {
+                return 'No leg IDs captured. Run "startTrip (multi-destination)" first.';
+              }
+              return Radar.updateTripLeg(
+                tripId: _tripId,
+                legId: _legIds.first,
+                status: 'arrived',
+              );
+            }),
+            ApiAction("updateCurrentTripLeg('arrived')",
+                () => Radar.updateCurrentTripLeg(status: 'arrived')),
+            ApiAction('reorderTripLegs (reversed)', () async {
+              if (_legIds.length < 2) {
+                return 'Need at least two legs. Run "startTrip (multi-destination)" first.';
+              }
+              return Radar.reorderTripLegs(
+                tripId: _tripId,
+                legIds: _legIds.reversed.toList(),
+              );
+            }),
+            ApiAction('completeTrip()', () => Radar.completeTrip()),
+            ApiAction('cancelTrip()', () => Radar.cancelTrip()),
+          ],
+        ),
+        ApiSection(
+          title: 'Geofences & Search',
+          icon: Icons.search,
+          actions: [
+            ApiAction('searchGeofences()', () => Radar.searchGeofences(
+                  near: Map<String, dynamic>.from(_manhattan),
                   radius: 1000,
                   limit: 10,
                   includeGeometry: true,
                   tags: List.empty(),
                   metadata: {},
-                );
-                print("searchGeofences: $resp");
-              },
-              child: Text('searchGeofences()'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () async {
-                var resp = await Radar.geocode(
-                  '20 jay st brooklyn',
-                );
-                print("geocode: $resp");
-              },
-              child: Text('geocode()'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () async {
-                var resp = await Radar.reverseGeocode();
-                print("reverseGeocode: $resp");
-              },
-              child: Text('reverseGeocode()'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () async {
-                var resp = await Radar.autocomplete(
+                )),
+            ApiAction('searchPlaces()', () => Radar.searchPlaces(
+                  near: Map<String, dynamic>.from(_manhattan),
+                  radius: 1000,
+                  chains: ['starbucks'],
+                  chainMetadata: {'customFlag': 'true'},
+                  limit: 10,
+                )),
+            ApiAction('autocomplete()', () => Radar.autocomplete(
                   query: 'brooklyn roasting',
-                  near: {
-                    'latitude': 40.783826,
-                    'longitude': -73.975363,
-                  },
+                  near: Map<String, dynamic>.from(_manhattan),
                   limit: 10,
                   layers: ['address', 'street'],
                   country: 'US',
-                  mailable: false
-                );
-                print("autocomplete: $resp");
-              },
-              child: Text('autocomplete'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () async {
-                var resp = await Radar.getMatrix(
-                  origins: [
-                    {
-                      'latitude': 40.78382,
-                      'longitude': -73.97536,
-                    },
-                    {
-                      'latitude': 40.70390,
-                      'longitude': -73.98670,
-                    },
-                  ],
+                  mailable: false,
+                )),
+            ApiAction('geocode()', () => Radar.geocode('20 jay st brooklyn')),
+            ApiAction('reverseGeocode()', () => Radar.reverseGeocode()),
+            ApiAction('ipGeocode()', () => Radar.ipGeocode()),
+            ApiAction('getContext()',
+                () => Radar.getContext(Map<String, dynamic>.from(_manhattan))),
+            ApiAction('getDistance()', () => Radar.getDistance(
+                  origin: _manhattan,
+                  destination: _brooklyn,
+                  modes: ['car', 'foot'],
+                  units: 'imperial',
+                )),
+            ApiAction('getMatrix()', () => Radar.getMatrix(
+                  origins: [_manhattan, _brooklyn],
                   destinations: [
-                    {
-                      'latitude': 40.64189,
-                      'longitude': -73.78779,
-                    },
-                    {
-                      'latitude': 35.99801,
-                      'longitude': -78.94294,
-                    },
+                    {'latitude': 40.64189, 'longitude': -73.78779},
+                    {'latitude': 35.99801, 'longitude': -78.94294},
                   ],
                   mode: 'car',
                   units: 'imperial',
-                );
-                print("getMatrix: $resp");
-              },
-              child: Text('getMatrix'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () {
-                Radar.startTracking('responsive');
-              },
-              child: Text('startTracking(\'responsive\')'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () {
-                
-                Radar.setForegroundServiceOptions({
-                  'title': 'Tracking',
-                  'text': 'Continuous tracking started',
-                  'iconString': "ic_notification",
-                  'iconColor': "#FF6B8D",
-                  'importance': 2,
-                  'updatesOnly': false,
-                  'activity': 'io.radar.example.MainActivity'
-                });
-                Radar.startTrackingCustom({
-                  'desiredStoppedUpdateInterval': 120,
-                  'fastestStoppedUpdateInterval': 120,
-                  'desiredMovingUpdateInterval': 30,
-                  'fastestMovingUpdateInterval': 30,
-                  'desiredSyncInterval': 20,
-                  'desiredAccuracy': 'high',
-                  'stopDuration': 140,
-                  'stopDistance': 70,
-                  'sync': 'all',
-                  'replay': 'none',
-                  'showBlueBar': true,
-                  'foregroundServiceEnabled': true
-                });
-              },
-              child: Text('startTrackingCustom()'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () {
-                Radar.startTrackingVerified(30, false);
-              },
-              child: Text('startTrackingVerified()'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () {
-                Radar.stopTrackingVerified();
-              },
-              child: Text('stopTrackingVerified()'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () {
-                Radar.stopTracking();
-              },
-              child: Text('stopTracking()'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () {
-                Radar.mockTracking(
-                    origin: {'latitude': 40.78382, 'longitude': -73.97536},
-                    destination: {'latitude': 40.70390, 'longitude': -73.98670},
-                    mode: 'car',
-                    steps: 3,
-                    interval: 3);
-              },
-              child: Text('mockTracking()'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () async {
-                Map? location = await Radar.getLocation('high');
-                print(location);
-              },
-              child: Text('getLocation()'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () async {
-                Map? resp = await Radar.trackVerified();
-                print("trackVerified: $resp");
-              },
-              child: Text('trackVerified()'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () async {
-                var resp = await Radar.getVerifiedLocationToken();
-                print("getVerifiedLocationToken: $resp");
-              },
-              child: Text('getVerifiedLocationToken()'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () async {
-                bool? resp = await Radar.isUsingRemoteTrackingOptions();
-                print("isUsingRemoteTrackingOptions: $resp");
-              },
-              child: Text('isUsingRemoteTrackingOptions'),
-            ),
-            ElevatedButton(
-              style: raisedButtonStyle,
-              onPressed: () async {
-                Map? resp = await Radar.validateAddress({
-                  "city": "NEW YORK",
-                  "stateCode": "NY",
-                  "postalCode": "10003",
-                  "countryCode": "US",
-                  "street": "BROADWAY",
-                  "number": "841",
-                });
-                print("validateAddress: $resp");
-              },
-              child: Text('validateAddress'),
-            ),
-          ]),
-        )
-      ),
-    ));
-  }
-}
-
-class Permissions extends StatefulWidget {
-  @override
-  _PermissionsState createState() => _PermissionsState();
-}
-
-class _PermissionsState extends State<Permissions> {
-  String? _status = 'NOT_DETERMINED';
-  final ButtonStyle raisedButtonStyle = ElevatedButton.styleFrom(
-    minimumSize: Size(88, 36),
-    padding: EdgeInsets.symmetric(horizontal: 16),
-    shape: const RoundedRectangleBorder(
-      borderRadius: BorderRadius.all(Radius.circular(2)),
-    ),
-  );
-
-  @override
-  void initState() {
-    super.initState();
-    _getPermissionsStatus();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        Text(
-          '$_status',
-          style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+                )),
+            ApiAction('validateAddress()', () => Radar.validateAddress({
+                  'city': 'NEW YORK',
+                  'stateCode': 'NY',
+                  'postalCode': '10003',
+                  'countryCode': 'US',
+                  'street': 'BROADWAY',
+                  'number': '841',
+                })),
+          ],
         ),
-        ElevatedButton(
-          style: raisedButtonStyle,
-          child: Text('getPermissionsStatus()'),
-          onPressed: () {
-            _getPermissionsStatus();
-          },
+        ApiSection(
+          title: 'Events & Conversions',
+          icon: Icons.event_note_outlined,
+          actions: [
+            ApiAction('logConversion()', () => Radar.logConversion(
+                  name: 'in_app_purchase',
+                  revenue: 0.2,
+                  metadata: {'price': '150USD'},
+                )),
+            ApiAction('acceptEvent()', () async {
+              final eventId = await _prompt('acceptEvent — event ID');
+              if (eventId == null || eventId.isEmpty) return 'cancelled';
+              await Radar.acceptEvent(eventId);
+              return 'accepted $eventId';
+            }),
+            ApiAction('rejectEvent()', () async {
+              final eventId = await _prompt('rejectEvent — event ID');
+              if (eventId == null || eventId.isEmpty) return 'cancelled';
+              await Radar.rejectEvent(eventId);
+              return 'rejected $eventId';
+            }),
+            ApiAction('logBackgrounding()', () async {
+              await Radar.logBackgrounding();
+              return 'ok';
+            }),
+            ApiAction('logResigningActive()', () async {
+              await Radar.logResigningActive();
+              return 'ok';
+            }),
+            ApiAction('logTermination()', () async {
+              await Radar.logTermination();
+              return 'ok';
+            }),
+          ],
         ),
-      ],
-    );
-  }
-
-  Future _getPermissionsStatus() async {
-    String? status = await Radar.getPermissionsStatus();
-    setState(() {
-      _status = status;
-    });
-  }
-}
-
-class TrackOnce extends StatefulWidget {
-  @override
-  _TrackOnceState createState() => _TrackOnceState();
-}
-
-class _TrackOnceState extends State<TrackOnce> {
-  final ButtonStyle raisedButtonStyle = ElevatedButton.styleFrom(
-    minimumSize: Size(88, 36),
-    padding: EdgeInsets.symmetric(horizontal: 16),
-    shape: const RoundedRectangleBorder(
-      borderRadius: BorderRadius.all(Radius.circular(2)),
-    ),
-  );
-
-  @override
-  Widget build(BuildContext context) {
-    return ElevatedButton(
-      child: Text('trackOnce()'),
-      style: raisedButtonStyle,
-      onPressed: () {
-        _showTrackOnceDialog();
-      },
-    );
-  }
-
-  Future<void> _showTrackOnceDialog() async {
-    var trackResponse = await Radar.trackOnce();
-    print("trackResponse: $trackResponse");
-
-    Widget okButton = TextButton(
-      child: Text('OK'),
-      onPressed: () {
-        Navigator.pop(context);
-      },
-    );
-
-    AlertDialog alert = AlertDialog(
-      title: Text('flutter_radar_example'),
-      content: Text(trackResponse?['status'] ?? ''),
-      actions: [
-        okButton,
-      ],
-    );
-
-    showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return alert;
-      },
-    );
-  }
-}
-
-showAlertDialog(BuildContext context, String text) {
-  Widget okButton = TextButton(
-    child: Text('OK'),
-    onPressed: () {
-      Navigator.of(context).pop();
-    },
-  );
-
-  AlertDialog alert = AlertDialog(
-    title: Text('flutter_radar_example'),
-    content: Text(text),
-    actions: [
-      okButton,
-    ],
-  );
-
-  showDialog(
-    context: context,
-    builder: (BuildContext context) {
-      return alert;
-    },
-  );
+        ApiSection(
+          title: 'Notifications & Messaging',
+          icon: Icons.notifications_none,
+          actions: [
+            ApiAction('setNotificationOptions()', () async {
+              await Radar.setNotificationOptions({'iconString': 'icon'});
+              return 'ok';
+            }),
+            ApiAction('setPushNotificationToken()', () async {
+              final token = await _prompt('setPushNotificationToken');
+              if (token == null) return 'cancelled';
+              await Radar.setPushNotificationToken(token);
+              return token.isEmpty ? 'cleared' : token;
+            }),
+            ApiAction('showInAppMessage()', () async {
+              await Radar.showInAppMessage({
+                'type': 'banner',
+                'title': {'text': 'This is the title', 'color': '#000000'},
+                'body': {'text': 'This is a demo message', 'color': '#666666'},
+                'button': {
+                  'text': 'Send it',
+                  'color': '#FFFFFF',
+                  'backgroundColor': '#EB0083',
+                },
+              });
+              return 'shown';
+            }),
+          ],
+        ),
+      ];
 }

--- a/ios/Classes/RadarFlutterPlugin.m
+++ b/ios/Classes/RadarFlutterPlugin.m
@@ -542,10 +542,19 @@
         result(dict);
     };
     NSDictionary *argsDict = call.arguments;
-    NSDictionary *tripOptionsDict = argsDict[@"tripOptions"];
+    // Dart sends every key, so an omitted argument arrives as NSNull rather
+    // than nil. The SDK's parsers only guard against nil, so NSNull reaches
+    // objectForKeyedSubscript: and raises.
+    NSDictionary *tripOptionsDict = [argsDict[@"tripOptions"] isKindOfClass:[NSDictionary class]] ? argsDict[@"tripOptions"] : nil;
+    if (!tripOptionsDict) {
+        result([FlutterError errorWithCode:@"ERROR_INVALID_ARGUMENT"
+                                   message:@"startTrip requires tripOptions"
+                                   details:nil]);
+        return;
+    }
     RadarTripOptions *tripOptions = [RadarTripOptions tripOptionsFromDictionary:tripOptionsDict];
-    NSDictionary *trackingOptionsDict = argsDict[@"trackingOptions"];
-    RadarTrackingOptions *trackingOptions = [RadarTrackingOptions trackingOptionsFromDictionary:trackingOptionsDict];
+    NSDictionary *trackingOptionsDict = [argsDict[@"trackingOptions"] isKindOfClass:[NSDictionary class]] ? argsDict[@"trackingOptions"] : nil;
+    RadarTrackingOptions *trackingOptions = trackingOptionsDict ? [RadarTrackingOptions trackingOptionsFromDictionary:trackingOptionsDict] : nil;
 
     [Radar startTripWithOptions:tripOptions trackingOptions:trackingOptions completionHandler:completionHandler];
 }
@@ -563,7 +572,13 @@
         result(dict);
     };
     NSDictionary *argsDict = call.arguments;
-    NSDictionary *tripOptionsDict = argsDict[@"tripOptions"];
+    NSDictionary *tripOptionsDict = [argsDict[@"tripOptions"] isKindOfClass:[NSDictionary class]] ? argsDict[@"tripOptions"] : nil;
+    if (!tripOptionsDict) {
+        result([FlutterError errorWithCode:@"ERROR_INVALID_ARGUMENT"
+                                   message:@"updateTrip requires tripOptions"
+                                   details:nil]);
+        return;
+    }
     RadarTripOptions *tripOptions = [RadarTripOptions tripOptionsFromDictionary:tripOptionsDict];
     NSString* statusStr = argsDict[@"status"];
     RadarTripStatus status = RadarTripStatusUnknown;


### PR DESCRIPTION
- Redesigns the example app into collapsible product-area sections covering the full Flutter Radar API surface, with an in-app console that shows only the response of the button that was pressed (listener events go to the terminal via `debugPrint`).
- Fixes an iOS hang in `startTrip` / `updateTrip` where omitted Dart args arrive as `NSNull` and crash the SDK's dictionary parsers; also corrects multi-destination trip leg `coordinates` to GeoJSON `[longitude, latitude]` order.

**iOS**
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/97334801-69b1-4c52-b04a-efcb9f6e727e" />

**Android**
<img width="1080" height="2400" alt="Screenshot_1785445896" src="https://github.com/user-attachments/assets/cbcc7f4b-8bb2-49dd-a984-6ac6f4e22284" />
